### PR TITLE
Feat/#29 마감된 공모 전달

### DIFF
--- a/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/controller/CahootsController.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/controller/CahootsController.java
@@ -3,6 +3,7 @@ package io.eagle.wealthmarblebackend.domain.vacation.controller;
 import io.eagle.wealthmarblebackend.domain.vacation.dto.BreifCahootListDto;
 import io.eagle.wealthmarblebackend.domain.vacation.dto.CreateCahootsDto;
 import io.eagle.wealthmarblebackend.domain.vacation.dto.DetailCahootsDto;
+import io.eagle.wealthmarblebackend.domain.vacation.entity.type.VacationStatusType;
 import io.eagle.wealthmarblebackend.domain.vacation.service.CahootsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -29,6 +30,13 @@ public class CahootsController {
 
     @GetMapping(params = "status=ongoing")
     public BreifCahootListDto getBreifCahootsInfo(Integer offset){
-        return cahootsService.getBreifList(offset);
+        VacationStatusType[] types = new VacationStatusType[]{VacationStatusType.CAHOOTS_ONGOING};
+        return cahootsService.getBreifList(types, offset);
+    }
+
+    @GetMapping(params = "status=ended")
+    public BreifCahootListDto getEndedBreifCahootsInfo(){
+        VacationStatusType[] types = new VacationStatusType[]{VacationStatusType.CAHOOTS_CLOSE, VacationStatusType.CAHOOTS_OPEN};
+        return cahootsService.getBreifList(types, 0);
     }
 }

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/dto/BreifCahootsDto.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/dto/BreifCahootsDto.java
@@ -21,6 +21,8 @@ public class BreifCahootsDto {
 
     private Long stockPrice;
 
+    private Integer stockNum;
+
     private Integer competitionRate;
 
     // TODO : hashtag

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/entity/Vacation.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/entity/Vacation.java
@@ -2,7 +2,6 @@ package io.eagle.wealthmarblebackend.domain.vacation.entity;
 
 import io.eagle.wealthmarblebackend.common.BaseEntity;
 import io.eagle.wealthmarblebackend.domain.ContestParticipation.entity.ContestParticipation;
-import io.eagle.wealthmarblebackend.domain.cahoots.domain.embeded.Plan;
 import io.eagle.wealthmarblebackend.domain.picture.entity.Picture;
 import io.eagle.wealthmarblebackend.domain.user.domain.User;
 import io.eagle.wealthmarblebackend.domain.vacation.dto.CreateCahootsDto;

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/repository/VacationCustom.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/repository/VacationCustom.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface VacationCustom {
     List<?> getVacationDetail(Long cahootsId);
-    List<BreifCahootsDto> getVacationsBreif(VacationStatusType status, Integer offset);
+    List<BreifCahootsDto> getVacationsBreif(VacationStatusType[] statusTypes, Integer offset);
 }

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/repository/VacationCustomImpl.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/repository/VacationCustomImpl.java
@@ -34,7 +34,7 @@ public class VacationCustomImpl implements VacationCustom {
                 .fetch();
     }
 
-    public List<BreifCahootsDto> getVacationsBreif(VacationStatusType status, Integer offset){
+    public List<BreifCahootsDto> getVacationsBreif(VacationStatusType[] statusTypes, Integer offset){
         QVacation vacation = QVacation.vacation;
         QContestParticipation cp = QContestParticipation.contestParticipation;
         // TODO : picture 추가
@@ -51,7 +51,7 @@ public class VacationCustomImpl implements VacationCustom {
                         ExpressionUtils.as((cp.stocks.sum().coalesce(0).multiply(100).divide(vacation.stock.num)),"competitionRate")))
                 .from(vacation)
                 .leftJoin(vacation.historyList, cp)
-                .where(vacation.status.eq(status))
+                .where(vacation.status.in(statusTypes))
                 .groupBy(vacation.id)
                 .orderBy(cp.stocks.sum().desc())
                 .limit(this.page)

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/repository/VacationCustomImpl.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/repository/VacationCustomImpl.java
@@ -46,6 +46,7 @@ public class VacationCustomImpl implements VacationCustom {
                         vacation.location,
                         vacation.status,
                         ExpressionUtils.as(vacation.stock.price,"stockPrice"),
+                        ExpressionUtils.as(vacation.stock.num,"stockNum"),
                         ExpressionUtils.as(vacation.stockPeriod.start, "stockStart"),
                         ExpressionUtils.as(vacation.stockPeriod.end, "stockEnd"),
                         ExpressionUtils.as((cp.stocks.sum().coalesce(0).multiply(100).divide(vacation.stock.num)),"competitionRate")))

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/service/CahootsService.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/service/CahootsService.java
@@ -48,8 +48,8 @@ public class CahootsService {
         return DetailCahootsDto.toDto(vacation, competitionRate);
     }
 
-    public BreifCahootListDto getBreifList(Integer offset){
-        List<BreifCahootsDto> breifCahootsList = vacationRepository.getVacationsBreif(VacationStatusType.CAHOOTS_ONGOING, offset);
+    public BreifCahootListDto getBreifList(VacationStatusType[] types, Integer offset){
+        List<BreifCahootsDto> breifCahootsList = vacationRepository.getVacationsBreif(types, offset);
         return BreifCahootListDto.builder().result(breifCahootsList).build();
     }
 }


### PR DESCRIPTION
## 💬 Issue Number

> closes #29

## 🤷‍♂️ Description

> 작업 내용에 대한 설명

`/api/cahoots?status=ended`
마감된 공모 리스트 전달.
마감 기준 : 공모가 끝나거나, 마켓으로 변경되었을 때

![image](https://user-images.githubusercontent.com/34162358/214546667-7010ea9b-f2af-4ff3-94ac-6c6084c1d68c.png)

## 📷 Screenshots

> 작업 결과물

<img width="311" alt="image" src="https://user-images.githubusercontent.com/34162358/214551226-04234fa5-0889-41bf-8ca2-07ca1bf02929.png">

<img width="274" alt="image" src="https://user-images.githubusercontent.com/34162358/214551334-4b44e567-d49d-4a65-9a43-99ba6310d174.png">


## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항

현재 진행중인 공모의 간략 정보와 마감된 공모에 필요한 데이터가 거의 유사하여 service, repository layer를 공통으로 사용했습니다.
지금 공모 타입이 약간 애매한데, CAHOOTS_OPEN을 market open으로 바꿀까요??
```java
    CAHOOTS_BEFORE("CAHOOTS_BEFORE"),
    CAHOOTS_ONGOING("CAHOOTS_ONGOING"), // 공모 진행 중
    CAHOOTS_OPEN("CAHOOTS_OPEN"), // 마켓 오픈
    CAHOOTS_CLOSE("CAHOOTS_CLOSE"); // 공모 끝남
```
뒤에 PR 하나 더 있습니다..ㅎㅎ
