### PR TITLE
Feat/ API 이미지 url 추가

### DIFF
--- a/src/main/java/io/eagle/wealthmarblebackend/domain/ContestParticipation/dto/HistoryCahootsDto.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/ContestParticipation/dto/HistoryCahootsDto.java
@@ -1,13 +1,10 @@
 package io.eagle.wealthmarblebackend.domain.ContestParticipation.dto;
 
 import io.eagle.wealthmarblebackend.domain.ContestParticipation.entity.ContestParticipation;
-import lombok.Builder;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 
 @Data
 @RequiredArgsConstructor
@@ -18,7 +15,7 @@ public class HistoryCahootsDto {
     private final Integer stocks;
 
 
-    public static HistoryCahootsDto toDto(ContestParticipation c){
-        return new HistoryCahootsDto(c.getCreatedAt(), c.getStocks());
+    public static HistoryCahootsDto toDto(ContestParticipation contestParticipation){
+        return new HistoryCahootsDto(contestParticipation.getCreatedAt(), contestParticipation.getStocks());
     }
 }

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/ContestParticipation/repository/ContestParticipationRepositoryImpl.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/ContestParticipation/repository/ContestParticipationRepositoryImpl.java
@@ -2,11 +2,12 @@ package io.eagle.wealthmarblebackend.domain.ContestParticipation.repository;
 
 import com.querydsl.jpa.JPQLQueryFactory;
 import io.eagle.wealthmarblebackend.domain.ContestParticipation.entity.ContestParticipation;
-import io.eagle.wealthmarblebackend.domain.ContestParticipation.entity.QContestParticipation;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 import java.util.Optional;
+
+import static io.eagle.wealthmarblebackend.domain.ContestParticipation.entity.QContestParticipation.contestParticipation;
 
 @RequiredArgsConstructor
 public class ContestParticipationRepositoryImpl implements ContestParticipationRepositoryCustom {
@@ -14,21 +15,19 @@ public class ContestParticipationRepositoryImpl implements ContestParticipationR
 
     @Override
     public Optional<Integer> getCurrentContestNum(Long cahootsId) {
-        QContestParticipation cp = QContestParticipation.contestParticipation;
         return Optional.ofNullable(queryFactory
-                    .select(cp.stocks.sum())
-                    .from(cp)
-                    .where(cp.vacation.id.eq(cahootsId))
+                    .select(contestParticipation.stocks.sum())
+                    .from(contestParticipation)
+                    .where(contestParticipation.vacation.id.eq(cahootsId))
                     .fetchOne());
     }
 
     @Override
     public List<ContestParticipation> findAllByCahootsId(Long cahootsId){
-        QContestParticipation cp = QContestParticipation.contestParticipation;
         return queryFactory
-                .selectFrom(cp)
-                .where(cp.vacation.id.eq(cahootsId))
-                .orderBy(cp.createdAt.desc())
+                .selectFrom(contestParticipation)
+                .where(contestParticipation.vacation.id.eq(cahootsId))
+                .orderBy(contestParticipation.createdAt.desc())
                 .fetch();
 
     }

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/picture/repository/PictureRepository.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/picture/repository/PictureRepository.java
@@ -3,5 +3,5 @@ package io.eagle.wealthmarblebackend.domain.picture.repository;
 import io.eagle.wealthmarblebackend.domain.picture.entity.Picture;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PictureRepository extends JpaRepository<Picture, Long> {
+public interface PictureRepository extends JpaRepository<Picture, Long>, PictureRepositoryCustom {
 }

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/picture/repository/PictureRepositoryCustom.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/picture/repository/PictureRepositoryCustom.java
@@ -1,0 +1,9 @@
+package io.eagle.wealthmarblebackend.domain.picture.repository;
+
+import io.eagle.wealthmarblebackend.domain.picture.entity.Picture;
+
+import java.util.List;
+
+public interface PictureRepositoryCustom {
+    List<String> findUrlsByCahootsId(Long cahootsId);
+}

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/picture/repository/PictureRepositoryCustomImpl.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/picture/repository/PictureRepositoryCustomImpl.java
@@ -1,0 +1,24 @@
+package io.eagle.wealthmarblebackend.domain.picture.repository;
+
+import com.querydsl.jpa.JPQLQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static io.eagle.wealthmarblebackend.domain.picture.entity.QPicture.picture;
+
+@RequiredArgsConstructor
+public class PictureRepositoryCustomImpl implements PictureRepositoryCustom{
+    private final JPQLQueryFactory queryFactory;
+
+
+    @Override
+    public List<String> findUrlsByCahootsId(Long cahootsId){
+        return queryFactory
+                .select(picture.url)
+                .from(picture)
+                .where(picture.vacation.id.eq(cahootsId))
+                .fetch();
+
+    }
+}

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/dto/BreifCahootsDto.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/dto/BreifCahootsDto.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Data
 @NoArgsConstructor
@@ -28,6 +29,6 @@ public class BreifCahootsDto {
     // TODO : hashtag
 
     // TODO : picture url
-//    private final List<String> images = new ArrayList<>();
+    private List<String> images;
 
 }

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/dto/BreifV2CahootsDto.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/dto/BreifV2CahootsDto.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Data
 @NoArgsConstructor
@@ -17,7 +18,6 @@ public class BreifV2CahootsDto {
 
     private LocalDate stockEnd;
 
-    // TODO : picture url
-//    private final List<String> images = new ArrayList<>();
+    private List<String> images;
 
 }

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/dto/CreateCahootsDto.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/dto/CreateCahootsDto.java
@@ -58,6 +58,9 @@ public class CreateCahootsDto {
     @Positive(message = "목표 공모 주식 수를 작성해주세요.")
     private final Integer stockNum;
 
+    @Positive(message = "예상 수익률을 작성해주세요.")
+    private final Integer expectedRateOfReturn;
+
     // TODO : hashtag
 
     private final List<MultipartFile> images;

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/dto/DetailCahootsDto.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/dto/DetailCahootsDto.java
@@ -47,6 +47,8 @@ public class DetailCahootsDto {
 
     private Integer competitionRate;
 
+    private Integer expectedRateOfReturn;
+
     // TODO : hashtag
 
     private List<String> images;

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/dto/DetailCahootsDto.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/dto/DetailCahootsDto.java
@@ -49,7 +49,6 @@ public class DetailCahootsDto {
 
     // TODO : hashtag
 
-    // TODO : picture url
     private List<String> images;
 
 //    public static DetailCahootsDto toDto(Vacation vacation, Integer competitionRate) {

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/dto/DetailCahootsDto.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/dto/DetailCahootsDto.java
@@ -1,11 +1,11 @@
 package io.eagle.wealthmarblebackend.domain.vacation.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
 import io.eagle.wealthmarblebackend.domain.vacation.entity.Vacation;
 import io.eagle.wealthmarblebackend.domain.vacation.entity.type.ThemeBuildingType;
 import io.eagle.wealthmarblebackend.domain.vacation.entity.type.ThemeLocationType;
 import io.eagle.wealthmarblebackend.domain.vacation.entity.type.VacationStatusType;
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 import java.time.LocalDate;
@@ -13,60 +13,62 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Data
-@Builder
+@NoArgsConstructor
 public class DetailCahootsDto {
 
-    private final Long id;
-    private final String title;
+    private Long id;
+    private String title;
 
-    private final ThemeLocationType themeLocation;
+    private ThemeLocationType themeLocation;
 
-    private final ThemeBuildingType themeBuilding;
+    private ThemeBuildingType themeBuilding;
 
-    private final String location;
+    private String location;
 
-    private final Integer expectedMonth;
+    private Integer expectedMonth;
 
-    private final Long expectedTotalCost;
-
-    @NotBlank
-    private final String shortDescription;
+    private Long expectedTotalCost;
 
     @NotBlank
-    private final String descritption;
+    private String shortDescription;
 
-    private final VacationStatusType status;
+    @NotBlank
+    private String descritption;
 
-    private final LocalDate stockStart;
+    private VacationStatusType status;
 
-    private final LocalDate stockEnd;
+    private LocalDate stockStart;
 
-    private final Long stockPrice;
+    private LocalDate stockEnd;
 
-    private final Integer competitionRate;
+    private Long stockPrice;
+
+    private Integer stockNum;
+
+    private Integer competitionRate;
 
     // TODO : hashtag
 
     // TODO : picture url
-    private final List<String> images = new ArrayList<>();
+    private List<String> images;
 
-    public static DetailCahootsDto toDto(Vacation vacation, Integer competitionRate) {
-        return DetailCahootsDto.builder()
-                .id(vacation.getId())
-                .title(vacation.getTitle())
-                .descritption(vacation.getDescritption())
-                .location(vacation.getLocation())
-                .expectedMonth(vacation.getPlan().getExpectedMonth())
-                .expectedTotalCost(vacation.getPlan().getExpectedTotalCost())
-                .shortDescription(vacation.getShortDescription())
-                .stockStart(vacation.getStockPeriod().getStart())
-                .stockEnd(vacation.getStockPeriod().getEnd())
-                .stockPrice(vacation.getStock().getPrice())
-                .competitionRate(competitionRate)
-                .themeLocation(vacation.getTheme().getThemeLocation())
-                .themeBuilding(vacation.getTheme().getThemeBuilding())
-                .status(vacation.getStatus())
-                .build();
-
-    }
+//    public static DetailCahootsDto toDto(Vacation vacation, Integer competitionRate) {
+//        return DetailCahootsDto.builder()
+//                .id(vacation.getId())
+//                .title(vacation.getTitle())
+//                .descritption(vacation.getDescritption())
+//                .location(vacation.getLocation())
+//                .expectedMonth(vacation.getPlan().getExpectedMonth())
+//                .expectedTotalCost(vacation.getPlan().getExpectedTotalCost())
+//                .shortDescription(vacation.getShortDescription())
+//                .stockStart(vacation.getStockPeriod().getStart())
+//                .stockEnd(vacation.getStockPeriod().getEnd())
+//                .stockPrice(vacation.getStock().getPrice())
+//                .competitionRate(competitionRate)
+//                .themeLocation(vacation.getTheme().getThemeLocation())
+//                .themeBuilding(vacation.getTheme().getThemeBuilding())
+//                .status(vacation.getStatus())
+//                .build();
+//
+//    }
 }

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/entity/Vacation.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/entity/Vacation.java
@@ -73,6 +73,9 @@ public class Vacation extends BaseEntity {
     @OneToMany(mappedBy="vacation", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<ContestParticipation> historyList;
 
+    @NotNull
+    private Integer expectedRateOfReturn;
+
     @Builder
     public Vacation(CreateCahootsDto createCahootsDto) {
         this.status = VacationStatusType.CAHOOTS_BEFORE;
@@ -96,6 +99,7 @@ public class Vacation extends BaseEntity {
                         .price(createCahootsDto.getStockPrice())
                         .num(createCahootsDto.getStockNum())
                         .build();
+        this.expectedRateOfReturn = createCahootsDto.getExpectedRateOfReturn();
     }
 
     public void setPictureList(List<Picture> pictureList) {

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/entity/Vacation.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/entity/Vacation.java
@@ -67,11 +67,11 @@ public class Vacation extends BaseEntity {
     @Embedded
     private Stock stock;
 
-    @OneToMany(mappedBy = "vacation", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "vacation", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Picture> pictureList;
 
-    @OneToMany(mappedBy="vacation", fetch = FetchType.LAZY)
-    private Set<ContestParticipation> historyList = new LinkedHashSet<>();
+    @OneToMany(mappedBy="vacation", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<ContestParticipation> historyList;
 
     @Builder
     public Vacation(CreateCahootsDto createCahootsDto) {

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/repository/VacationCustom.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/repository/VacationCustom.java
@@ -1,14 +1,14 @@
 package io.eagle.wealthmarblebackend.domain.vacation.repository;
 
 import io.eagle.wealthmarblebackend.domain.vacation.dto.BreifCahootsDto;
+import io.eagle.wealthmarblebackend.domain.vacation.dto.DetailCahootsDto;
 import io.eagle.wealthmarblebackend.domain.vacation.dto.BreifV2CahootsDto;
 import io.eagle.wealthmarblebackend.domain.vacation.dto.InfoConditionDto;
-import io.eagle.wealthmarblebackend.domain.vacation.entity.type.VacationStatusType;
 
 import java.util.List;
 
 public interface VacationCustom {
-    List<?> getVacationDetail(Long cahootsId);
+    DetailCahootsDto getVacationDetail(Long cahootsId);
     List<BreifCahootsDto> getVacationsBreif(InfoConditionDto infoConditionDto);
     List<BreifV2CahootsDto> getVacationsBreifV2(InfoConditionDto infoConditionDto);
 }

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/repository/VacationCustomImpl.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/repository/VacationCustomImpl.java
@@ -32,16 +32,28 @@ public class VacationCustomImpl implements VacationCustom {
     private Integer beforeDays;
 
 
-    public List<?> getVacationDetail(Long cahootsId){
-
+    public DetailCahootsDto getVacationDetail(Long cahootsId){
         return queryFactory
-                .select(vacation, cp.stocks.sum())
+                .select(Projections.fields(DetailCahootsDto.class,
+                        vacation.id,
+                        vacation.title,
+                        vacation.location,
+                        vacation.status,
+                        vacation.theme.themeLocation,
+                        vacation.theme.themeBuilding,
+                        vacation.plan.expectedTotalCost,
+                        vacation.plan.expectedMonth,
+                        vacation.shortDescription,
+                        vacation.descritption,
+                        vacation.stock.price.as("stockPrice"),
+                        vacation.stock.num.as("stockNum"),
+                        vacation.stockPeriod.start.as("stockStart"),
+                        vacation.stockPeriod.end.as("stockEnd"),
+                        ExpressionUtils.as((contestParticipation.stocks.sum().coalesce(0).multiply(100).divide(vacation.stock.num)), "competitionRate")))
                 .from(vacation)
-                .leftJoin(vacation.historyList, cp)
+                .leftJoin(vacation.historyList, contestParticipation)
                 .where(vacation.id.eq(cahootsId))
-                .fetchJoin()
-                .distinct()
-                .fetch();
+                .fetchOne();
     }
 
     public List<BreifCahootsDto> getVacationsBreif(InfoConditionDto infoConditionDto){

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/repository/VacationCustomImpl.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/repository/VacationCustomImpl.java
@@ -57,7 +57,6 @@ public class VacationCustomImpl implements VacationCustom {
     }
 
     public List<BreifCahootsDto> getVacationsBreif(InfoConditionDto infoConditionDto){
-        // TODO : picture 추가
         // TODO : no limit, offset 검토
         return queryFactory
                 .select(Projections.fields(BreifCahootsDto.class,
@@ -82,7 +81,6 @@ public class VacationCustomImpl implements VacationCustom {
     }
 
     public List<BreifV2CahootsDto> getVacationsBreifV2(InfoConditionDto infoConditionDto){
-        // TODO : picture 추가
         // TODO : no limit, offset 검토
         return queryFactory
                 .select(Projections.fields(BreifV2CahootsDto.class,

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/repository/VacationCustomImpl.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/repository/VacationCustomImpl.java
@@ -45,6 +45,7 @@ public class VacationCustomImpl implements VacationCustom {
                         vacation.plan.expectedMonth,
                         vacation.shortDescription,
                         vacation.descritption,
+                        vacation.expectedRateOfReturn,
                         vacation.stock.price.as("stockPrice"),
                         vacation.stock.num.as("stockNum"),
                         vacation.stockPeriod.start.as("stockStart"),

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/service/CahootsService.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/service/CahootsService.java
@@ -2,29 +2,20 @@ package io.eagle.wealthmarblebackend.domain.vacation.service;
 
 import io.eagle.wealthmarblebackend.domain.picture.S3;
 import io.eagle.wealthmarblebackend.domain.picture.entity.Picture;
-import io.eagle.wealthmarblebackend.domain.ContestParticipation.repository.ContestParticipationRepository;
+import io.eagle.wealthmarblebackend.domain.picture.repository.PictureRepository;
 import io.eagle.wealthmarblebackend.domain.vacation.dto.*;
 import io.eagle.wealthmarblebackend.domain.vacation.entity.Vacation;
-import io.eagle.wealthmarblebackend.domain.vacation.entity.type.VacationStatusType;
 import io.eagle.wealthmarblebackend.domain.vacation.repository.VacationRepository;
-import io.eagle.wealthmarblebackend.exception.ApiException;
-import io.eagle.wealthmarblebackend.exception.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.ArrayList;
 import java.util.List;
-
-import java.util.List;
-
 
 @Service
 @RequiredArgsConstructor
 public class CahootsService {
 
     private final VacationRepository vacationRepository;
-    private final ContestParticipationRepository contestParticipationRepository;
+    private final PictureRepository pictureRepository;
     private final S3 s3;
 
     public void create(CreateCahootsDto createCahootsDto) {
@@ -39,10 +30,10 @@ public class CahootsService {
     }
 
     public DetailCahootsDto getDetail(Long cahootsId) {
-        Vacation vacation = vacationRepository.findById(cahootsId).orElseThrow(()-> new ApiException(ErrorCode.VACATION_NOT_FOUND));
-        Integer currentTotalStock = contestParticipationRepository.getCurrentContestNum(cahootsId).orElse(0);
-        Integer competitionRate =  currentTotalStock * 100 / vacation.getStock().getNum();
-        return DetailCahootsDto.toDto(vacation, competitionRate);
+        DetailCahootsDto detailCahootsDto = vacationRepository.getVacationDetail(cahootsId);
+        List<String> urls = pictureRepository.findUrlsByCahootsId(cahootsId);
+        detailCahootsDto.setImages(urls);
+        return detailCahootsDto;
     }
 
     public BreifCahootsListDto getBreifList(InfoConditionDto infoConditionDto){

--- a/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/service/CahootsService.java
+++ b/src/main/java/io/eagle/wealthmarblebackend/domain/vacation/service/CahootsService.java
@@ -31,18 +31,23 @@ public class CahootsService {
 
     public DetailCahootsDto getDetail(Long cahootsId) {
         DetailCahootsDto detailCahootsDto = vacationRepository.getVacationDetail(cahootsId);
-        List<String> urls = pictureRepository.findUrlsByCahootsId(cahootsId);
-        detailCahootsDto.setImages(urls);
+        detailCahootsDto.setImages(getImageUrls(cahootsId));
         return detailCahootsDto;
     }
 
     public BreifCahootsListDto getBreifList(InfoConditionDto infoConditionDto){
         List<BreifCahootsDto> breifCahootsList = vacationRepository.getVacationsBreif(infoConditionDto);
+        breifCahootsList.forEach(breifCahootsDto -> {breifCahootsDto.setImages(getImageUrls(breifCahootsDto.getId()));});
         return BreifCahootsListDto.builder().result(breifCahootsList).build();
     }
 
     public BreifV2CahootsListDto getBreifV2List(InfoConditionDto infoConditionDto){
         List<BreifV2CahootsDto> breifCahootsList = vacationRepository.getVacationsBreifV2(infoConditionDto);
+        breifCahootsList.forEach(breifCahootsDto -> {breifCahootsDto.setImages(getImageUrls(breifCahootsDto.getId()));});
         return BreifV2CahootsListDto.builder().result(breifCahootsList).build();
+    }
+
+    public List<String> getImageUrls(Long id){
+        return pictureRepository.findUrlsByCahootsId(id);
     }
 }


### PR DESCRIPTION
## 💬 Issue Number

> none

## 🤷‍♂️ Description

> 작업 내용에 대한 설명

수정한 API 목록
- [x] : 공모 간략 정보 list + (검색)
- [x] : 마감 임박 공보 전달 list
- [x] : 마감된 공모 전달 list

## 📷 Screenshots

> 작업 결과물

<img width="645" alt="image" src="https://user-images.githubusercontent.com/34162358/214759939-4f7672b0-d18c-4443-9b25-c073c2779b76.png">


## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항

여기 부분이 공모 정보에서 사진 url을 각각 받아오는 부분인데, OneToMany를 query로 한번에 아름답게.. 받아오는 방법을 아시나요.
어제 계속 고민했는데, 해답을 찾진 못했어요.

```java
public BreifCahootsListDto getBreifList(InfoConditionDto infoConditionDto){
        List<BreifCahootsDto> breifCahootsList = vacationRepository.getVacationsBreif(infoConditionDto);
        breifCahootsList.forEach(breifCahootsDto -> {breifCahootsDto.setImages(getImageUrls(breifCahootsDto.getId()));});
        return BreifCahootsListDto.builder().result(breifCahootsList).build();
  }
```