### PR TITLE
fix/#41 JWT Token 저장 로직 및 결과 반환 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,5 @@ application-cloud.yml
 application-oauth.yml
 
 # generated
-core/src/main/generated/
+/src/main/generated/
+/core/src/main/generated/

--- a/api/src/main/java/io/eagle/config/SecurityConfig.java
+++ b/api/src/main/java/io/eagle/config/SecurityConfig.java
@@ -39,7 +39,6 @@ public class SecurityConfig {
             .csrf().disable()
             .cors().disable()
             .httpBasic().disable()
-            .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class) // JWT filter 적용
             .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)// Spring Security에서 session을 사용하지 않도록 설정
             .and()
@@ -48,6 +47,7 @@ public class SecurityConfig {
                 .antMatchers("/api/v1/users/**").hasRole("USER")
                 .antMatchers("/**").permitAll()
             .and()
+            .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class) // JWT filter 적용
             .oauth2Login()
                 .successHandler(oAuth2SuccessHandler)
                 .userInfoEndpoint().userService(oAuth2UserService).and().and().build();

--- a/api/src/main/java/io/eagle/domain/user/dto/CreateUserDto.java
+++ b/api/src/main/java/io/eagle/domain/user/dto/CreateUserDto.java
@@ -8,11 +8,13 @@ import lombok.NoArgsConstructor;
 @Getter
 public class CreateUserDto {
 
+    private String providerId;
     private String email;
     private String nickname;
 
     @Builder
-    public CreateUserDto(String email, String nickname) {
+    public CreateUserDto(String providerId, String email, String nickname) {
+        this.providerId = providerId;
         this.email = email;
         this.nickname = nickname;
     }

--- a/api/src/main/java/io/eagle/domain/user/mapper/UserRequestMapper.java
+++ b/api/src/main/java/io/eagle/domain/user/mapper/UserRequestMapper.java
@@ -12,6 +12,7 @@ public class UserRequestMapper {
     public CreateUserDto toCreateUserDto(OAuth2User oAuth2User) {
         Map<String, Object> attributes = oAuth2User.getAttributes();
         return CreateUserDto.builder()
+            .providerId((String) attributes.get("sub"))
             .email((String) attributes.get("email"))
             .nickname((String) attributes.get("name"))
             .build();

--- a/api/src/main/java/io/eagle/domain/user/repository/UserRepository.java
+++ b/api/src/main/java/io/eagle/domain/user/repository/UserRepository.java
@@ -10,5 +10,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
 
     Optional<User> findByNickname(String nickname);
+    Optional<User> findUserByProviderId(String providerId);
 
 }

--- a/api/src/main/java/io/eagle/security/jwt/JwtTokenProvider.java
+++ b/api/src/main/java/io/eagle/security/jwt/JwtTokenProvider.java
@@ -46,68 +46,37 @@ public class JwtTokenProvider {
         return getClaimFromToken(token, Claims::getId);
     }
 
-    // Token 만료 일자 조회
-    public Date getExpirationDateFromToken(String token) {
-        return getClaimFromToken(token, Claims::getExpiration);
-    }
-
-    // Token 만료 여부 확인
-    public Boolean isTokenExpired(String token) {
-        final Date expiration = getExpirationDateFromToken(token);
-        return expiration.before(new Date());
+    // accessToken, refreshToken 동시 생성
+    public String generateTokenSet(String nickname, Map<String, Object> claims) {
+        saveRefreshToken(nickname);
+        return generateAccessToken(nickname, claims);
     }
 
     // access token 생성
-    public String generateAccessToken(String id, Map<String, Object> claims) {
-        return doGenerateAccesssToken(id, claims);
-    }
-
-    private String doGenerateAccesssToken(String id, Map<String, Object> claims) {
-        String accessToken = Jwts.builder()
+    private String generateAccessToken(String nickname, Map<String, Object> claims) {
+        return Jwts.builder()
             .setClaims(claims)
-            .setId(id)
+            .setId(nickname)
             .setIssuedAt(new Date(System.currentTimeMillis()))
             .setExpiration(new Date(System.currentTimeMillis() + TOKEN_VALID_TIME))
             .signWith(SignatureAlgorithm.HS512, secretKey)
             .compact();
-        return accessToken;
     }
 
     // id로 refreshToken 생성
-    public String generateRefreshToken(String id) {
-        return doGenerateRefreshToken(id);
-    }
-
-    private String doGenerateRefreshToken(String id) {
-        String refreshToken = Jwts.builder()
-            .setId(id)
+    private String generateRefreshToken(String nickname) {
+        return Jwts.builder()
+            .setId(nickname)
             .setIssuedAt(new Date(System.currentTimeMillis()))
-            .setExpiration(new Date(System.currentTimeMillis() + TOKEN_VALID_TIME * 24 *7))
+            .setExpiration(new Date(System.currentTimeMillis() + TOKEN_VALID_TIME * 24 * 7))
             .signWith(SignatureAlgorithm.HS512, secretKey)
             .compact();
-        return refreshToken;
-    }
-
-    // accessToken, refreshToken 동시 생성
-    public Map<String, String> generateTokenSet(String id, Map<String, Object> claims) {
-        return doGenerateTokenSet(id, claims);
-    }
-
-    private Map<String, String> doGenerateTokenSet(String id, Map<String, Object> claims) {
-        Map<String, String> tokens = new HashMap<String, String>();
-
-        String accessToken = doGenerateAccesssToken(id, claims);
-        String refreshToken = doGenerateRefreshToken(id);
-
-        tokens.put("accessToken", accessToken);
-        tokens.put("refreshToken", refreshToken);
-        return tokens;
     }
 
     // JWT refreshToken 만료체크 후 재발급
-    public Boolean reGenerateRefreshToken(String id) throws Exception {
+    public Boolean reGenerateRefreshToken(String nickname) throws Exception {
         // id 즉, nickname 으로 User 조회
-        User user = userRepository.findByNickname(id).orElse(null);
+        User user = userRepository.findByNickname(nickname).orElse(null);
 
         // User가 존재하지 않거나 refresh 토큰이 존재하지 않을 경우
         if (user == null || user.getRefreshToken() == null) {
@@ -119,12 +88,20 @@ public class JwtTokenProvider {
             Jwts.parser().setSigningKey(secretKey).parseClaimsJws(refreshToken);
             return true;
         } catch (ExpiredJwtException e) {
-            user.setRefreshToken(generateRefreshToken(id));
+            user.setRefreshToken(generateRefreshToken(nickname));
             userRepository.save(user);
             return true;
         } catch (Exception e) {
             e.printStackTrace();
             return false;
+        }
+    }
+
+    private void saveRefreshToken(String nickname) {
+        User user = userRepository.findByNickname(nickname).orElse(null);
+        if (user != null) {
+            user.setRefreshToken(generateRefreshToken(nickname));
+            userRepository.save(user);
         }
     }
 

--- a/api/src/main/java/io/eagle/security/oauth/CustomOAuth2UserService.java
+++ b/api/src/main/java/io/eagle/security/oauth/CustomOAuth2UserService.java
@@ -36,7 +36,6 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         OAuthAttributes attributes = OAuthAttributes.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
 
         User user = saveOrUpdate(attributes);
-
         return new DefaultOAuth2User(
             Collections.singleton(new SimpleGrantedAuthority(user.getRole().toString())),
             attributes.getAttributes(),

--- a/api/src/main/java/io/eagle/security/oauth/OAuth2SuccessHandler.java
+++ b/api/src/main/java/io/eagle/security/oauth/OAuth2SuccessHandler.java
@@ -33,10 +33,10 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
         CreateUserDto createUserDto = userRequestMapper.toCreateUserDto(oAuth2User);
 
-        Claims claims = Jwts.claims().setSubject(createUserDto.getNickname());
+        Claims claims = Jwts.claims().setSubject(createUserDto.getProviderId());
         claims.put("role", "USER");
 
-        String accessToken = jwtTokenProvider.generateTokenSet(createUserDto.getNickname(), claims);
+        String accessToken = jwtTokenProvider.generateTokenSet(createUserDto.getProviderId(), claims);
 
         response.setContentType("application/json");
         response.setCharacterEncoding("utf-8");


### PR DESCRIPTION
## 💬 Issue Number

> closes #41

## 🤷‍♂️ Description

> 작업 내용에 대한 설명

- [x] : JWT token parse 로직 변경

## 👻 Good Function

> 팀원에게 공유하고 싶은 함수나 코드 일부

```
@GetMapping(value = "/user")
public void getUsers(@RequestHeader(name="Authorization") String token) {
	String providerId = jwtProvider.getUsernameFromToken(token);
}

@GetMapping(value = "/user")
public void getUsers(@AuthenticationPrincipal User user) {
	String nickname = user.getUsername();
}
```

이렇게 @RequestHeader를 넣고 해당 토큰을 jwtProvider로 Parsing해서 사용할 수가 있어요 파싱을 하면 해당 token user의 providerId를 받을 수 있어요 아니면 @AuthenticationPrincipal을 하시면 가능해요

## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항
