### PR TITLE
Feat/#56 Websocket 기본 연결

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -1,0 +1,7 @@
+spring:
+  profiles:
+    include:
+      - core
+      - mysql
+      - oauth
+      - cloud

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 	}
 	dependencies {
 		classpath "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}"
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.11.RELEASE"
+		classpath "io.spring.gradle:dependency-management-plugin:1.1.0"
 	}
 }
 
@@ -147,6 +147,9 @@ project(':socket'){
 	dependencies {
 		implementation project(':core')
 		implementation 'org.springframework.boot:spring-boot-starter-websocket'
+		implementation 'org.springframework.kafka:spring-kafka'
+		testImplementation 'org.springframework.kafka:spring-kafka-test'
+		implementation "com.google.guava:guava:31.1-jre"
 	}
 }
 

--- a/core/src/main/resources/application-core.yml
+++ b/core/src/main/resources/application-core.yml
@@ -1,9 +1,8 @@
 spring:
-  profiles:
-    include:
-      - mysql
-      - cloud
-      - oauth
+#  profiles:
+#    include:
+#      - mysql
+#      - oauth
   jpa:
     hibernate:
       ddl-auto: update

--- a/settings/README.md
+++ b/settings/README.md
@@ -1,0 +1,13 @@
+## kafka docker 설정
+
+```shell
+$ docker-compose -f docker-compose.yml up -d
+$ docker-compose exec kafka kafka-topics --create --topic kafka-market --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+$ docker-compose exec kafka kafka-topics --describe --topic kafka-market --bootstrap-server kafka:9092
+```
+1 line : docker-compose 실행
+
+2 line : topic (kafka-market) 생성
+
+3 line : kafka-market topic이 있는지 확인
+

--- a/settings/docker-compose.yml
+++ b/settings/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '2'
+
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    environment:
+      ZOOKEEPER_SERVER_ID: 1
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+      ZOOKEEPER_INIT_LIMIT: 5
+      ZOOKEEPER_SYNC_LIMIT: 2
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    depends_on:
+      - zookeeper
+    ports:
+      - "29092:29092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0

--- a/socket/src/main/java/io/eagle/Main.java
+++ b/socket/src/main/java/io/eagle/Main.java
@@ -1,7 +1,0 @@
-package io.eagle;
-
-public class Main {
-    public static void main(String[] args) {
-        System.out.println("Hello world!");
-    }
-}

--- a/socket/src/main/java/io/eagle/SocketApplication.java
+++ b/socket/src/main/java/io/eagle/SocketApplication.java
@@ -1,0 +1,16 @@
+package io.eagle;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+//import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+
+//@EnableWebSecurity
+@EnableJpaAuditing
+@SpringBootApplication
+public class SocketApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(SocketApplication.class, args);
+    }
+}

--- a/socket/src/main/java/io/eagle/common/KafkaConstants.java
+++ b/socket/src/main/java/io/eagle/common/KafkaConstants.java
@@ -1,0 +1,7 @@
+package io.eagle.common;
+
+public final class KafkaConstants {
+    public static final String KAFKA_TOPIC = "kafka-market";
+    public static final String GROUP_ID = "eagle";
+    public static final String BROKER = "localhost:29092";
+}

--- a/socket/src/main/java/io/eagle/config/KafkaConsumerConfig.java
+++ b/socket/src/main/java/io/eagle/config/KafkaConsumerConfig.java
@@ -1,0 +1,50 @@
+package io.eagle.config;
+
+import com.google.common.collect.ImmutableMap;
+import io.eagle.common.KafkaConstants;
+import io.eagle.domain.market.dto.MessageDto;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.Map;
+
+@Configuration
+@EnableKafka
+public class KafkaConsumerConfig {
+
+    @Bean
+    ConcurrentKafkaListenerContainerFactory<String, MessageDto> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, MessageDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+
+    @Bean
+    public ConsumerFactory<String, MessageDto> consumerFactory() {
+        return new DefaultKafkaConsumerFactory<>(consumerConfigurations(), new StringDeserializer(), new JsonDeserializer<>(MessageDto.class));
+    }
+
+    @Bean
+    public Map<String, Object> consumerConfigurations() {
+        JsonDeserializer<MessageDto> deserializer = new JsonDeserializer<>(MessageDto.class);
+        deserializer.setRemoveTypeHeaders(false);
+        deserializer.addTrustedPackages("*");
+        deserializer.setUseTypeMapperForKey(true);
+
+        return ImmutableMap.<String, Object>builder()
+                .put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaConstants.BROKER)
+                .put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringSerializer.class)
+                .put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class)
+                .put(ConsumerConfig.GROUP_ID_CONFIG, KafkaConstants.GROUP_ID)
+                .put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,"latest")
+                .build();
+    }
+}

--- a/socket/src/main/java/io/eagle/config/KafkaProducerConfig.java
+++ b/socket/src/main/java/io/eagle/config/KafkaProducerConfig.java
@@ -1,0 +1,41 @@
+package io.eagle.config;
+
+import com.google.common.collect.ImmutableMap;
+import io.eagle.common.KafkaConstants;
+import io.eagle.domain.market.dto.MessageDto;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.Map;
+
+@Configuration
+@EnableKafka
+public class KafkaProducerConfig {
+
+    @Bean
+    public ProducerFactory<String, MessageDto> producerFactory() {
+        return new DefaultKafkaProducerFactory<>(kafkaProducerConfiguration());
+    }
+
+    @Bean
+    public Map<String, Object> kafkaProducerConfiguration() {
+        return ImmutableMap.<String, Object>builder()
+                .put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaConstants.BROKER)
+                .put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
+                .put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class)
+//                .put("group.id", KafkaConstants.GROUP_ID)
+                .build();
+    }
+
+    @Bean
+    public KafkaTemplate<String, MessageDto> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/socket/src/main/java/io/eagle/config/WebSocketConfig.java
+++ b/socket/src/main/java/io/eagle/config/WebSocketConfig.java
@@ -1,0 +1,23 @@
+package io.eagle.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.*;
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws-market")
+                .setAllowedOriginPatterns("*");
+//                .withSockJS();
+    } // handshake endpoint
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.setApplicationDestinationPrefixes("/purchase"); // client -> server
+        config.enableSimpleBroker("/topic"); // broker로 가세요.. 구독 요청
+    }
+
+}

--- a/socket/src/main/java/io/eagle/domain/market/consumer/MarketConsumer.java
+++ b/socket/src/main/java/io/eagle/domain/market/consumer/MarketConsumer.java
@@ -14,9 +14,9 @@ public class MarketConsumer {
     private final SimpMessagingTemplate template;
 
     @KafkaListener( topics = KafkaConstants.KAFKA_TOPIC, groupId = KafkaConstants.GROUP_ID )
-    public void listen(MessageDto message){
+    public void listen(MessageDto message){ // kafka listener에서 듣고있음
         System.out.println("kafka consumer.. ");
         System.out.println(message);
-        template.convertAndSend("/topic/market/" + message.getMarketId(), message);
+        template.convertAndSend("/topic/market/" + message.getMarketId(), message); // topic/market/{마켓아이디}를 듣고있는 client에 전송
     }
 }

--- a/socket/src/main/java/io/eagle/domain/market/consumer/MarketConsumer.java
+++ b/socket/src/main/java/io/eagle/domain/market/consumer/MarketConsumer.java
@@ -1,0 +1,22 @@
+package io.eagle.domain.market.consumer;
+
+import io.eagle.common.KafkaConstants;
+import io.eagle.domain.market.dto.MessageDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MarketConsumer {
+
+    private final SimpMessagingTemplate template;
+
+    @KafkaListener( topics = KafkaConstants.KAFKA_TOPIC, groupId = KafkaConstants.GROUP_ID )
+    public void listen(MessageDto message){
+        System.out.println("kafka consumer.. ");
+        System.out.println(message);
+        template.convertAndSend("/topic/market/" + message.getMarketId(), message);
+    }
+}

--- a/socket/src/main/java/io/eagle/domain/market/controller/MarketController.java
+++ b/socket/src/main/java/io/eagle/domain/market/controller/MarketController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MarketController {
     private final KafkaTemplate<String, MessageDto> kafkaTemplate;
 
-    @MessageMapping("/") //   url : "/purchase/"
+    @MessageMapping("/") //   url : "/purchase/" 로 들어오는 정보 처리
     public void buy(MessageDto message){
         // 사용자 잔액 조회
         // 구매

--- a/socket/src/main/java/io/eagle/domain/market/controller/MarketController.java
+++ b/socket/src/main/java/io/eagle/domain/market/controller/MarketController.java
@@ -1,0 +1,24 @@
+package io.eagle.domain.market.controller;
+
+import io.eagle.common.KafkaConstants;
+import io.eagle.domain.market.dto.MessageDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MarketController {
+    private final KafkaTemplate<String, MessageDto> kafkaTemplate;
+
+    @MessageMapping("/") //   url : "/purchase/"
+    public void buy(MessageDto message){
+        // 사용자 잔액 조회
+        // 구매
+        // broadcasting
+        System.out.println("producer");
+        kafkaTemplate.send(KafkaConstants.KAFKA_TOPIC, message);
+    }
+
+}

--- a/socket/src/main/java/io/eagle/domain/market/dto/MessageDto.java
+++ b/socket/src/main/java/io/eagle/domain/market/dto/MessageDto.java
@@ -1,0 +1,11 @@
+package io.eagle.domain.market.dto;
+
+import lombok.Data;
+
+@Data
+public class MessageDto {
+
+    private Integer marketId;
+    private Integer price;
+    private Integer amount;
+}

--- a/socket/src/main/resources/application.yml
+++ b/socket/src/main/resources/application.yml
@@ -1,0 +1,16 @@
+spring:
+  profiles:
+    include:
+      - core
+      - mysql
+      - oauth
+
+#  devtools:
+#    restart:
+#      log-condition-evaluation-delta=false:
+logging:
+  level:
+    org:
+      springframework:
+        boot:
+          autoconfigure: INFO


### PR DESCRIPTION
## 💬 Issue Number

> closes #56

## 🤷‍♂️ Description

> 작업 내용에 대한 설명

socket test 할때는 apic 이라는 chrome extension을 사용했습니다.
kafka local 설정을 위해 docker-compose 와 설정 방법을 README.md에 작성했습니다.
오늘 kafka 학습 마무리해서 글을 차근차근 써볼게요.

기본적으로 path는 다음과 같습니다.

- 연결 : `ws://localhost:8080/ws-market` (port는 api랑 겹쳐서 나중에 변경하겠습니다.)
- 구독 : `/topic`, 실제 client는 `/topic/market/{marketId}` 로 구독 요청 필요
- Client에서 보내는 정보 : `/purchase/`

현재 commit 까지는 security 가 core에 없어 안돌아가는데, security, user domain, 관련 config 설정을 core에 넣으면 송수신 잘 되는 것 까지 확인 했습니다.

# 📷 Screenshots

> 작업 결과물

<img width="1562" alt="image" src="https://user-images.githubusercontent.com/34162358/217236355-92a492ef-df5b-46ff-bc80-ae79cd1db60d.png">


## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항
