### PR TITLE
Feat/#83 마켓 정보에서 휴양지 상세 정보 가져오기

### DIFF
--- a/api/src/main/java/io/eagle/domain/vacation/controller/MarketController.java
+++ b/api/src/main/java/io/eagle/domain/vacation/controller/MarketController.java
@@ -20,4 +20,9 @@ public class MarketController {
         return ApiResponse.createSuccess(marketService.getOne(vacationId));
     }
 
+    @GetMapping("/markets/info/{vacationId}")
+    public ApiResponse getInfo(@PathVariable("vacationId") Long vacationId) {
+        return ApiResponse.createSuccess(marketService.getVacationInfo(vacationId));
+    }
+
 }

--- a/api/src/main/java/io/eagle/domain/vacation/dto/MarketInfoDto.java
+++ b/api/src/main/java/io/eagle/domain/vacation/dto/MarketInfoDto.java
@@ -1,0 +1,24 @@
+package io.eagle.domain.vacation.dto;
+
+import io.eagle.entity.Picture;
+import io.eagle.entity.Vacation;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class MarketInfoDto {
+    private String title;
+    private String location;
+    private String description;
+    private List<String> pictures;
+
+    public MarketInfoDto(Vacation vacation) {
+        this.title = vacation.getTitle();
+        this.location = vacation.getLocation();
+        this.description = vacation.getDescription();
+        this.pictures = vacation.getPictureList() != null ? vacation.getPictureList().stream().map(Picture::getUrl).collect(Collectors.toList()) : null;
+    }
+}

--- a/api/src/main/java/io/eagle/domain/vacation/dto/response/MarketDetailDto.java
+++ b/api/src/main/java/io/eagle/domain/vacation/dto/response/MarketDetailDto.java
@@ -1,4 +1,4 @@
-package io.eagle.domain.vacation.dto;
+package io.eagle.domain.vacation.dto.response;
 
 import io.eagle.entity.Picture;
 import lombok.Builder;

--- a/api/src/main/java/io/eagle/domain/vacation/dto/response/MarketInfoDto.java
+++ b/api/src/main/java/io/eagle/domain/vacation/dto/response/MarketInfoDto.java
@@ -1,4 +1,4 @@
-package io.eagle.domain.vacation.dto;
+package io.eagle.domain.vacation.dto.response;
 
 import io.eagle.entity.Picture;
 import io.eagle.entity.Vacation;
@@ -15,10 +15,10 @@ public class MarketInfoDto {
     private String description;
     private List<String> pictures;
 
-    public MarketInfoDto(Vacation vacation) {
+    public MarketInfoDto(Vacation vacation, List<String> pictures) {
         this.title = vacation.getTitle();
         this.location = vacation.getLocation();
         this.description = vacation.getDescription();
-        this.pictures = vacation.getPictureList() != null ? vacation.getPictureList().stream().map(Picture::getUrl).collect(Collectors.toList()) : null;
+        this.pictures = pictures;
     }
 }

--- a/api/src/main/java/io/eagle/domain/vacation/service/MarketService.java
+++ b/api/src/main/java/io/eagle/domain/vacation/service/MarketService.java
@@ -4,6 +4,7 @@ import io.eagle.domain.interest.repository.InterestRepository;
 import io.eagle.domain.picture.repository.PictureRepository;
 import io.eagle.domain.transaction.repository.TransactionRepository;
 import io.eagle.domain.vacation.dto.MarketDetailDto;
+import io.eagle.domain.vacation.dto.MarketInfoDto;
 import io.eagle.domain.vacation.repository.VacationRepository;
 import io.eagle.entity.Transaction;
 import io.eagle.entity.Vacation;
@@ -41,6 +42,14 @@ public class MarketService {
                 .pictures(pictures)
                 .userIds(userIds)
                 .build();
+        }
+        return null;
+    }
+
+    public MarketInfoDto getVacationInfo(Long vacationId) {
+        Vacation vacation = vacationRepository.findById(vacationId).orElse(null);
+        if (vacation != null) {
+            return new MarketInfoDto(vacation);
         }
         return null;
     }

--- a/api/src/main/java/io/eagle/domain/vacation/service/MarketService.java
+++ b/api/src/main/java/io/eagle/domain/vacation/service/MarketService.java
@@ -3,8 +3,8 @@ package io.eagle.domain.vacation.service;
 import io.eagle.domain.interest.repository.InterestRepository;
 import io.eagle.domain.picture.repository.PictureRepository;
 import io.eagle.domain.transaction.repository.TransactionRepository;
-import io.eagle.domain.vacation.dto.MarketDetailDto;
-import io.eagle.domain.vacation.dto.MarketInfoDto;
+import io.eagle.domain.vacation.dto.response.MarketDetailDto;
+import io.eagle.domain.vacation.dto.response.MarketInfoDto;
 import io.eagle.domain.vacation.repository.VacationRepository;
 import io.eagle.entity.Transaction;
 import io.eagle.entity.Vacation;
@@ -49,7 +49,8 @@ public class MarketService {
     public MarketInfoDto getVacationInfo(Long vacationId) {
         Vacation vacation = vacationRepository.findById(vacationId).orElse(null);
         if (vacation != null) {
-            return new MarketInfoDto(vacation);
+            List<String> pictures = pictureRepository.findUrlsByCahootsId(vacationId);
+            return new MarketInfoDto(vacation, pictures);
         }
         return null;
     }

--- a/api/src/test/java/io/eagle/domain/vacation/service/MarketServiceTest.java
+++ b/api/src/test/java/io/eagle/domain/vacation/service/MarketServiceTest.java
@@ -4,7 +4,7 @@ import io.eagle.common.TestUtil;
 import io.eagle.domain.interest.repository.InterestRepository;
 import io.eagle.domain.picture.repository.PictureRepository;
 import io.eagle.domain.transaction.repository.TransactionRepository;
-import io.eagle.domain.vacation.dto.MarketInfoDto;
+import io.eagle.domain.vacation.dto.response.MarketInfoDto;
 import io.eagle.domain.vacation.repository.VacationRepository;
 import io.eagle.entity.User;
 import io.eagle.entity.Vacation;

--- a/api/src/test/java/io/eagle/domain/vacation/service/MarketServiceTest.java
+++ b/api/src/test/java/io/eagle/domain/vacation/service/MarketServiceTest.java
@@ -1,0 +1,59 @@
+package io.eagle.domain.vacation.service;
+
+import io.eagle.common.TestUtil;
+import io.eagle.domain.interest.repository.InterestRepository;
+import io.eagle.domain.picture.repository.PictureRepository;
+import io.eagle.domain.transaction.repository.TransactionRepository;
+import io.eagle.domain.vacation.dto.MarketInfoDto;
+import io.eagle.domain.vacation.repository.VacationRepository;
+import io.eagle.entity.User;
+import io.eagle.entity.Vacation;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@ExtendWith(SpringExtension.class)
+public class MarketServiceTest {
+
+    @Mock
+    private VacationRepository vacationRepository;
+    @Mock
+    private TransactionRepository transactionRepository;
+    @Mock
+    private PictureRepository pictureRepository;
+    @Mock
+    private InterestRepository interestRepository;
+
+    @InjectMocks
+    private MarketService marketService;
+
+    @Test
+    @DisplayName("휴양지_상세_정보_가져오기")
+    void getVacationInfo() {
+        // given
+        TestUtil testUtil = new TestUtil();
+
+        User user = testUtil.createUser("anonymous", "anonymous@email.com");
+        Vacation vacation = testUtil.createVacation(user);
+        Long vacationId = 1L;
+        when(vacationRepository.findById(vacationId)).thenReturn(Optional.of(vacation));
+
+        // when
+        MarketInfoDto marketInfoDto = marketService.getVacationInfo(vacationId);
+
+        // then
+        assertEquals(marketInfoDto.getDescription(), vacation.getDescription());
+        assertEquals(marketInfoDto.getLocation(), vacation.getLocation());
+        assertEquals(marketInfoDto.getTitle(), vacation.getTitle());
+    }
+
+}


### PR DESCRIPTION
## 💬 Issue Number

> closes #83 

## 🤷‍♂️ Description

> 작업 내용에 대한 설명

- [x] MarketServiceTest 작성하기
- [x] MarketInfoDto 선언
- [x] getVacationInfo 구현
- [x] [GET] /api/markets/info/{vacationId} 제작

## 📷 Screenshots

> 작업 결과물

<img width="329" alt="스크린샷 2023-02-11 오후 3 25 47" src="https://user-images.githubusercontent.com/55318896/218244189-1992c1d3-d093-4eea-84d9-b1f32be3a89a.png">

## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?