### PR TITLE
Feat/#92 User Interest에 pagination 적용

### DIFF
--- a/api/src/main/java/io/eagle/domain/interest/controller/InterestController.java
+++ b/api/src/main/java/io/eagle/domain/interest/controller/InterestController.java
@@ -5,8 +5,9 @@ import io.eagle.common.ApiResponse;
 import io.eagle.domain.interest.dto.InterestDto;
 import io.eagle.domain.interest.service.InterestService;
 import io.eagle.entity.Interest;
-import io.eagle.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,8 +24,13 @@ public class InterestController {
     }
 
     @GetMapping("/auth/interests/me")
-    public ApiResponse getAllUserInterests(@AuthenticationPrincipal AuthDetails authDetails) {
-        return ApiResponse.createSuccess(interestService.getAllInterest(authDetails.getUser()));
+    public ApiResponse getAllUserInterests(
+        @AuthenticationPrincipal AuthDetails authDetails,
+        @RequestParam(defaultValue = "10", required = false) Integer size,
+        @RequestParam(defaultValue = "0", required = false) Integer page
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        return ApiResponse.createSuccess(interestService.getAllInterest(authDetails.getUser(), pageable));
     }
 
     @PostMapping("/auth/interests")

--- a/api/src/main/java/io/eagle/domain/interest/repository/InterestRepositoryCustom.java
+++ b/api/src/main/java/io/eagle/domain/interest/repository/InterestRepositoryCustom.java
@@ -3,12 +3,13 @@ package io.eagle.domain.interest.repository;
 import io.eagle.entity.Interest;
 import io.eagle.entity.User;
 import io.eagle.entity.Vacation;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface InterestRepositoryCustom {
 
-    List<Interest> findAllByUser(User user);
+    List<Interest> findInterestByUser(User user, Pageable pageable);
     Boolean existsByUser(User user);
     Interest findByUserAndVacation(Long userId, Long vacationId);
     List<Interest> findAllByVacation(Long vacationId);

--- a/api/src/main/java/io/eagle/domain/interest/repository/InterestRepositoryImpl.java
+++ b/api/src/main/java/io/eagle/domain/interest/repository/InterestRepositoryImpl.java
@@ -1,13 +1,14 @@
 package io.eagle.domain.interest.repository;
 
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPQLQueryFactory;
 import io.eagle.entity.Interest;
 import io.eagle.entity.User;
-import io.eagle.entity.Vacation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static io.eagle.entity.QInterest.*;
 
@@ -17,14 +18,15 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom {
     private final JPQLQueryFactory jpqlQueryFactory;
 
     @Override
-    public List<Interest> findAllByUser(User user) {
+    public List<Interest> findInterestByUser(User user, Pageable pageable) {
         return jpqlQueryFactory
             .selectFrom(interest)
             .leftJoin(interest.user)
             .where(interest.user.id.eq(user.getId()))
-            .fetchAll()
-            .stream()
-            .collect(Collectors.toList());
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .orderBy(Expressions.dateTemplate(LocalDateTime.class, "DATE_FORMAT({0}, {1})", interest.createdAt, "%Y-%m-%d").desc())
+            .fetch();
     }
 
     @Override

--- a/api/src/main/java/io/eagle/domain/interest/service/InterestService.java
+++ b/api/src/main/java/io/eagle/domain/interest/service/InterestService.java
@@ -9,6 +9,7 @@ import io.eagle.entity.Interest;
 import io.eagle.entity.User;
 import io.eagle.entity.Vacation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -22,8 +23,8 @@ public class InterestService {
     private final UserRepository userRepository;
     private final VacationRepository vacationRepository;
 
-    public List<InterestInfoDto> getAllInterest(User user) {
-        return interestRepository.findAllByUser(user).stream().map(interest -> new InterestInfoDto(interest.getVacation())).collect(Collectors.toList());
+    public List<InterestInfoDto> getAllInterest(User user, Pageable pageable) {
+        return interestRepository.findInterestByUser(user, pageable).stream().map(interest -> new InterestInfoDto(interest.getVacation())).collect(Collectors.toList());
     }
 
     public Boolean isUserInterest(User user) {

--- a/api/src/test/java/io/eagle/common/TestUtil.java
+++ b/api/src/test/java/io/eagle/common/TestUtil.java
@@ -1,9 +1,6 @@
 package io.eagle.common;
 
-import io.eagle.entity.Order;
-import io.eagle.entity.Transaction;
-import io.eagle.entity.User;
-import io.eagle.entity.Vacation;
+import io.eagle.entity.*;
 import io.eagle.entity.embeded.Period;
 import io.eagle.entity.embeded.Plan;
 import io.eagle.entity.embeded.Stock;
@@ -25,6 +22,7 @@ public class TestUtil {
                 .location(ThemeLocationType.BEACH)
                 .build()
             )
+            .country("대한민국")
             .location("부산")
             .plan(Plan.builder()
                 .expectedMonth(12)
@@ -77,6 +75,13 @@ public class TestUtil {
             .sellOrder(sellOrder)
             .price(100)
             .amount(100)
+            .build();
+    }
+
+    public Interest createInterest(User user, Vacation vacation) {
+        return Interest.builder()
+            .user(user)
+            .vacation(vacation)
             .build();
     }
 }

--- a/api/src/test/java/io/eagle/domain/interest/repository/InterestRepositoryTest.java
+++ b/api/src/test/java/io/eagle/domain/interest/repository/InterestRepositoryTest.java
@@ -1,0 +1,69 @@
+package io.eagle.domain.interest.repository;
+
+import io.eagle.common.TestUtil;
+import io.eagle.config.TestConfig;
+import io.eagle.domain.vacation.repository.VacationRepository;
+import io.eagle.entity.Interest;
+import io.eagle.entity.User;
+import io.eagle.entity.Vacation;
+import io.eagle.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@Import(TestConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class InterestRepositoryTest {
+
+    @Autowired
+    private InterestRepository interestRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private VacationRepository vacationRepository;
+
+    User user;
+    Vacation vacation;
+    Interest interest;
+
+    void createObject() {
+        TestUtil testUtil = new TestUtil();
+        user = userRepository.save(testUtil.createUser("user", "user@email.com"));
+        vacation = vacationRepository.save(testUtil.createVacation(user));
+        interest = interestRepository.save(testUtil.createInterest(user, vacation));
+    }
+
+    @Test
+    @DisplayName("사용자_interest_조회")
+    @Transactional
+    void findInterestByUser() {
+        // given
+        createObject();
+        Pageable pageable = PageRequest.of(0, 20);
+
+        // when
+        List<Interest> interests = interestRepository.findInterestByUser(user, pageable);
+        Interest findInterest = interests.get(0);
+
+        // then
+        assertEquals(findInterest.getId(), interest.getId());
+        assertEquals(findInterest.getUser().getId(), interest.getUser().getId());
+        assertEquals(findInterest.getVacation().getId(), interest.getVacation().getId());
+    }
+
+}

--- a/core/src/main/java/io/eagle/entity/Interest.java
+++ b/core/src/main/java/io/eagle/entity/Interest.java
@@ -1,10 +1,16 @@
 package io.eagle.entity;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 public class Interest extends BaseEntity {
 


### PR DESCRIPTION
## 💬 Issue Number

> closes #92

## 🤷‍♂️ Description

> 작업 내용에 대한 설명

- [x] [GET] /auth/interests/me 페이지 적용
- [x] findAllByUser 에서 findInterestByUser로 변경
- [x] createInterest TestUtil 추가
- [x] 사용자_interest_조회 테스트 진행

## 📷 Screenshots

> 작업 결과물

<img width="338" alt="스크린샷 2023-02-13 오후 3 19 18" src="https://user-images.githubusercontent.com/55318896/218385875-2617d1d2-78d7-4cc1-b6c1-5d8b932b68c1.png">

## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?