### PR TITLE
Feat/#118 관심상품 필터링 기능 구현하기

### DIFF
--- a/api/src/main/java/io/eagle/domain/interest/controller/InterestController.java
+++ b/api/src/main/java/io/eagle/domain/interest/controller/InterestController.java
@@ -26,11 +26,12 @@ public class InterestController {
     @GetMapping("/auth/interests/me")
     public ApiResponse getAllUserInterests(
         @AuthenticationPrincipal AuthDetails authDetails,
+        @RequestParam(defaultValue = "market") String type,
         @RequestParam(defaultValue = "10", required = false) Integer size,
         @RequestParam(defaultValue = "0", required = false) Integer page
     ) {
         Pageable pageable = PageRequest.of(page, size);
-        return ApiResponse.createSuccess(interestService.getAllInterest(authDetails.getUser(), pageable));
+        return ApiResponse.createSuccess(interestService.getAllInterest(type, authDetails.getUser(), pageable));
     }
 
     @PostMapping("/auth/interests")

--- a/api/src/main/java/io/eagle/domain/interest/dto/InterestDto.java
+++ b/api/src/main/java/io/eagle/domain/interest/dto/InterestDto.java
@@ -18,4 +18,9 @@ public class InterestDto {
     @NotNull
     private Long vacationId;
 
+    public InterestDto(Long userId, Long vacationId) {
+        this.userId = userId;
+        this.vacationId = vacationId;
+    }
+
 }

--- a/api/src/main/java/io/eagle/domain/interest/service/InterestService.java
+++ b/api/src/main/java/io/eagle/domain/interest/service/InterestService.java
@@ -3,6 +3,7 @@ package io.eagle.domain.interest.service;
 import io.eagle.domain.interest.dto.InterestDto;
 import io.eagle.domain.interest.dto.InterestInfoDto;
 import io.eagle.domain.interest.repository.InterestRepository;
+import io.eagle.entity.type.VacationStatusType;
 import io.eagle.repository.UserRepository;
 import io.eagle.domain.vacation.repository.VacationRepository;
 import io.eagle.entity.Interest;
@@ -23,8 +24,16 @@ public class InterestService {
     private final UserRepository userRepository;
     private final VacationRepository vacationRepository;
 
-    public List<InterestInfoDto> getAllInterest(User user, Pageable pageable) {
-        return interestRepository.findInterestByUser(user, pageable).stream().map(interest -> new InterestInfoDto(interest.getVacation())).collect(Collectors.toList());
+    public List<InterestInfoDto> getAllInterest(String type, User user, Pageable pageable) {
+        return interestRepository.findInterestByUser(user, pageable).stream().map(interest -> {
+            VacationStatusType vacationType = interest.getVacation().getStatus();
+            if (type.equals("market") && vacationType.equals(VacationStatusType.MARKET_ONGOING)) {
+                return new InterestInfoDto(interest.getVacation());
+            } else if (type.equals("cahoot") && !vacationType.equals(VacationStatusType.MARKET_ONGOING)) {
+                return new InterestInfoDto(interest.getVacation());
+            }
+            return null;
+        }).collect(Collectors.toList());
     }
 
     public Boolean isUserInterest(User user) {

--- a/api/src/test/java/io/eagle/common/TestUtil.java
+++ b/api/src/test/java/io/eagle/common/TestUtil.java
@@ -8,6 +8,7 @@ import io.eagle.entity.embeded.Theme;
 import io.eagle.entity.type.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public class TestUtil {
 
@@ -42,6 +43,7 @@ public class TestUtil {
                 .build()
             )
             .expectedRateOfReturn(12)
+            .pictureList(List.of(new Picture("url", "type", null)))
             .build();
     }
 

--- a/api/src/test/java/io/eagle/domain/interest/service/InterestServiceTest.java
+++ b/api/src/test/java/io/eagle/domain/interest/service/InterestServiceTest.java
@@ -53,5 +53,25 @@ public class InterestServiceTest {
         assertEquals(createInterest.getUser(), interest.getUser());
         assertEquals(createInterest.getVacation(), interest.getVacation());
     }
-    
+
+    @Test
+    @DisplayName("관심상품_삭제하기")
+    void deleteInterest() {
+        // given
+        TestUtil testUtil = new TestUtil();
+        User user = testUtil.createUser("anonymous", "anonymous@email.com");
+        User anotherUser = testUtil.createUser("interest", "interest@email.com");
+        Vacation vacation = testUtil.createVacation(user);
+        Interest interest = testUtil.createInterest(anotherUser, vacation);
+        InterestDto interestDto = new InterestDto(1L, 1L);
+
+        // when
+        when(interestRepository.findByUserAndVacation(1L, 1L)).thenReturn(interest);
+        Boolean result = interestService.deleteInterest(interestDto);
+
+        // then
+        verify(interestRepository, times(1)).delete(interest);
+        assertEquals(result, true);
+    }
+
 }

--- a/api/src/test/java/io/eagle/domain/interest/service/InterestServiceTest.java
+++ b/api/src/test/java/io/eagle/domain/interest/service/InterestServiceTest.java
@@ -2,18 +2,23 @@ package io.eagle.domain.interest.service;
 
 import io.eagle.common.TestUtil;
 import io.eagle.domain.interest.dto.InterestDto;
+import io.eagle.domain.interest.dto.InterestInfoDto;
 import io.eagle.domain.interest.repository.InterestRepository;
 import io.eagle.domain.vacation.repository.VacationRepository;
 import io.eagle.entity.Interest;
 import io.eagle.entity.User;
 import io.eagle.entity.Vacation;
+import io.eagle.entity.type.VacationStatusType;
 import io.eagle.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
 
 import static org.mockito.Mockito.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -30,6 +35,31 @@ public class InterestServiceTest {
 
     @InjectMocks
     private InterestService interestService;
+
+    @Test
+    @DisplayName("내_관심상품_가져오기")
+    void getAllInterest() {
+        // given
+        TestUtil testUtil = new TestUtil();
+        User user = testUtil.createUser("anonymous", "anonymous@email.com");
+        User marketUser = testUtil.createUser("market", "market@email.com");
+        Vacation vacation = testUtil.createVacation(user);
+        vacation.setStatus(VacationStatusType.MARKET_ONGOING);
+        Interest interest = testUtil.createInterest(marketUser, vacation);
+        Pageable pageable = Pageable.ofSize(10);
+        String type = "market";
+
+        // when
+        when(interestRepository.findInterestByUser(marketUser, pageable)).thenReturn(List.of(interest));
+        List<InterestInfoDto> interestDtos = interestService.getAllInterest(type, marketUser, pageable);
+
+        // then
+        InterestInfoDto infoDto = interestDtos.get(0);
+        assertEquals(infoDto.getTitle(), vacation.getTitle());
+        assertEquals(infoDto.getShortDescription(), vacation.getShortDescription());
+        assertEquals(infoDto.getLocation(), vacation.getLocation());
+        assertEquals(infoDto.getPicture(), vacation.getPictureList().get(0));
+    }
 
     @Test
     @DisplayName("관심상품_생성하기")

--- a/api/src/test/java/io/eagle/domain/interest/service/InterestServiceTest.java
+++ b/api/src/test/java/io/eagle/domain/interest/service/InterestServiceTest.java
@@ -1,0 +1,57 @@
+package io.eagle.domain.interest.service;
+
+import io.eagle.common.TestUtil;
+import io.eagle.domain.interest.dto.InterestDto;
+import io.eagle.domain.interest.repository.InterestRepository;
+import io.eagle.domain.vacation.repository.VacationRepository;
+import io.eagle.entity.Interest;
+import io.eagle.entity.User;
+import io.eagle.entity.Vacation;
+import io.eagle.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+public class InterestServiceTest {
+
+    @Mock
+    private InterestRepository interestRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private VacationRepository vacationRepository;
+
+    @InjectMocks
+    private InterestService interestService;
+
+    @Test
+    @DisplayName("관심상품_생성하기")
+    void createInterest() {
+        // given
+        TestUtil testUtil = new TestUtil();
+        User user = testUtil.createUser("anonymous", "anonymous@email.com");
+        User anotherUser = testUtil.createUser("interest", "interest@email.com");
+        Vacation vacation = testUtil.createVacation(user);
+        Interest interest = testUtil.createInterest(anotherUser, vacation);
+        InterestDto interestDto = new InterestDto(1L, 1L);
+
+        // when
+        when(userRepository.getReferenceById(1L)).thenReturn(anotherUser);
+        when(vacationRepository.getReferenceById(1L)).thenReturn(vacation);
+        when(interestRepository.findByUserAndVacation(1L, 1L)).thenReturn(null);
+        when(interestRepository.save(new Interest(anotherUser, vacation))).thenReturn(interest);
+        Interest createInterest = interestService.createInterest(interestDto);
+
+        // then
+        assertEquals(createInterest.getUser(), interest.getUser());
+        assertEquals(createInterest.getVacation(), interest.getVacation());
+    }
+    
+}


### PR DESCRIPTION
## 💬 Issue Number

> closes #118

## 🤷‍♂️ Description

> 작업 내용에 대한 설명

- [x] 기존 interests API에서 pathvariable로 type 추가하기
- [x] 내_관심상품_가져오기 테스트 코드 작성
- [x] 관심상품_생성하기 테스트 코드 작성
- [x] 관심상품_삭제하기 테스트 코드 작성

## 📷 Screenshots

> 작업 결과물

<img width="351" alt="스크린샷 2023-02-20 오후 5 55 21" src="https://user-images.githubusercontent.com/55318896/220058654-96cc1bdd-69f7-49bb-80a0-6b1f6f04a68a.png">

## 👻 Good Function

> 팀원에게 공유하고 싶은 함수나 코드 일부

## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항

기존 JPA Pagination 에 더해 서비스 계층에서 필터링을 진행하게 되었습니다.
