### PR TITLE
Feat/#82 사용자 캐시 차감기능

### DIFF
--- a/api/src/main/java/io/eagle/domain/ContestParticipation/controller/ContestParticipationController.java
+++ b/api/src/main/java/io/eagle/domain/ContestParticipation/controller/ContestParticipationController.java
@@ -17,9 +17,9 @@ import java.util.Map;
 public class ContestParticipationController {
     private final ContestParticipationService contestParticipationService;
 
-    @PostMapping("/cahoots/{cahootsId}")
-    public ApiResponse participateCahoots (@PathVariable("cahootsId") Long cahootsId, @RequestBody Map<String,Integer> param){
-        contestParticipationService.participate(cahootsId, param.get("stocks"));
+    @PostMapping("/auth/cahoots/{cahootsId}")
+    public ApiResponse participateCahoots (@PathVariable("cahootsId") Long cahootsId, @RequestBody Map<String,Integer> param, @AuthenticationPrincipal AuthDetails authDetails){
+        contestParticipationService.participate(cahootsId, param.get("stocks"), authDetails.getUser());
         return ApiResponse.createSuccessWithNoContent();
     }
 

--- a/api/src/main/java/io/eagle/domain/user/dto/response/UserInfoDto.java
+++ b/api/src/main/java/io/eagle/domain/user/dto/response/UserInfoDto.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 public class UserInfoDto {
 
     private String username;
-    private Integer cash;
+    private Long cash;
     private Integer value;
     private String email;
     private ProviderType providerType;

--- a/api/src/main/java/io/eagle/domain/vacation/common/Utils.java
+++ b/api/src/main/java/io/eagle/domain/vacation/common/Utils.java
@@ -1,0 +1,13 @@
+package io.eagle.domain.vacation.common;
+
+import io.eagle.domain.vacation.dto.request.OptionalUserIdDto;
+
+public final class Utils {
+    public static Long getUserId(OptionalUserIdDto user){
+        if(user == null){
+            return null;
+        } else{
+            return user.getUserId();
+        }
+    }
+}

--- a/api/src/main/java/io/eagle/domain/vacation/controller/CahootsController.java
+++ b/api/src/main/java/io/eagle/domain/vacation/controller/CahootsController.java
@@ -2,8 +2,10 @@ package io.eagle.domain.vacation.controller;
 
 import io.eagle.auth.AuthDetails;
 import io.eagle.common.ApiResponse;
+import io.eagle.domain.vacation.common.Utils;
 import io.eagle.domain.vacation.dto.*;
 import io.eagle.domain.vacation.dto.request.CreateCahootsDto;
+import io.eagle.domain.vacation.dto.request.OptionalUserIdDto;
 import io.eagle.domain.vacation.dto.response.ImminentInfoDto;
 import io.eagle.entity.type.VacationStatusType;
 import io.eagle.domain.vacation.service.CahootsService;
@@ -26,13 +28,14 @@ public class CahootsController {
     }
 
     @GetMapping(value = "/cahoots/{cahootsId}", params = "info=detail")
-    public ApiResponse getCahootsDetailInfo(@PathVariable("cahootsId") Long cahootsId){
-        return ApiResponse.createSuccess(cahootsService.getDetail(cahootsId));
+    public ApiResponse getCahootsDetailInfo(@PathVariable("cahootsId") Long cahootsId, @RequestBody(required = false) OptionalUserIdDto user){
+        return ApiResponse.createSuccess(cahootsService.getDetail(cahootsId, Utils.getUserId(user)));
     }
 
     @GetMapping(value="/cahoots", params = "status=ongoing")
-    public ApiResponse getBreifCahootsInfo(@Valid InfoConditionDto infoConditionDto){
+    public ApiResponse getBreifCahootsInfo(@Valid InfoConditionDto infoConditionDto, @RequestBody(required = false) OptionalUserIdDto user){
         infoConditionDto.setTypes(new VacationStatusType[]{VacationStatusType.CAHOOTS_ONGOING});
+        infoConditionDto.setUserId(Utils.getUserId(user));
         return ApiResponse.createSuccess(cahootsService.getBreifList(infoConditionDto));
     }
 

--- a/api/src/main/java/io/eagle/domain/vacation/controller/CahootsController.java
+++ b/api/src/main/java/io/eagle/domain/vacation/controller/CahootsController.java
@@ -1,5 +1,6 @@
 package io.eagle.domain.vacation.controller;
 
+import io.eagle.auth.AuthDetails;
 import io.eagle.common.ApiResponse;
 import io.eagle.domain.vacation.dto.*;
 import io.eagle.domain.vacation.dto.request.CreateCahootsDto;
@@ -7,53 +8,54 @@ import io.eagle.domain.vacation.dto.response.ImminentInfoDto;
 import io.eagle.entity.type.VacationStatusType;
 import io.eagle.domain.vacation.service.CahootsService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
 @RestController
-@RequestMapping("/api/cahoots")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class CahootsController {
     private final CahootsService cahootsService;
 
-    @PostMapping
-    public ApiResponse createCahoots (@Valid CreateCahootsDto createCahootsDto){
-        cahootsService.create(createCahootsDto);
+    @PostMapping("/auth/cahoots")
+    public ApiResponse createCahoots (@Valid CreateCahootsDto createCahootsDto, @AuthenticationPrincipal AuthDetails authDetails){
+        cahootsService.create(createCahootsDto, authDetails.getUser());
         return ApiResponse.createSuccessWithNoContent();
     }
 
-    @GetMapping(value = "/{cahootsId}", params = "info=detail")
+    @GetMapping(value = "/cahoots/{cahootsId}", params = "info=detail")
     public ApiResponse getCahootsDetailInfo(@PathVariable("cahootsId") Long cahootsId){
         return ApiResponse.createSuccess(cahootsService.getDetail(cahootsId));
     }
 
-    @GetMapping(params = "status=ongoing")
+    @GetMapping(value="/cahoots", params = "status=ongoing")
     public ApiResponse getBreifCahootsInfo(@Valid InfoConditionDto infoConditionDto){
         infoConditionDto.setTypes(new VacationStatusType[]{VacationStatusType.CAHOOTS_ONGOING});
         return ApiResponse.createSuccess(cahootsService.getBreifList(infoConditionDto));
     }
 
-    @GetMapping(params = "status=ended")
+    @GetMapping(value="/cahoots", params = "status=ended")
     public ApiResponse getEndedBreifCahootsInfo(){
         VacationStatusType[] types = new VacationStatusType[]{VacationStatusType.CAHOOTS_CLOSE, VacationStatusType.CAHOOTS_OPEN};
         InfoConditionDto infoConditionDto = InfoConditionDto.builder().types(types).page(0).build();
         return ApiResponse.createSuccess(cahootsService.getBreifList(infoConditionDto));
     }
 
-    @GetMapping(params = "status=ending-soon")
+    @GetMapping(value="/cahoots",params = "status=ending-soon")
     public ApiResponse getEndedSoonBreifCahootsInfo(){
         VacationStatusType[] types = new VacationStatusType[]{VacationStatusType.CAHOOTS_ONGOING};
         InfoConditionDto infoConditionDto = InfoConditionDto.builder().types(types).page(0).build();
         return ApiResponse.createSuccess(cahootsService.getBreifV2List(infoConditionDto));
     }
 
-    @GetMapping(value= "/mini", params = "status=ending-soon")
+    @GetMapping(value= "/cahoots/mini", params = "status=ending-soon")
     public ApiResponse getMostImminentEndedSoon(){
         return ApiResponse.createSuccess(cahootsService.getMostImminentCahoots());
     }
 
-    @GetMapping("/recent")
+    @GetMapping("/cahoots/recent")
     public ApiResponse getlatestCahootsInfo(){
         return ApiResponse.createSuccess(cahootsService.getLatestsList());
     }

--- a/api/src/main/java/io/eagle/domain/vacation/dto/InfoConditionDto.java
+++ b/api/src/main/java/io/eagle/domain/vacation/dto/InfoConditionDto.java
@@ -9,6 +9,7 @@ import javax.validation.constraints.Min;
 @Data
 @Builder
 public class InfoConditionDto {
+    private Long userId;
     private VacationStatusType[] types;
     @Min(value = 0, message = "page는 0 이상이어야합니다.")
     private Integer page;

--- a/api/src/main/java/io/eagle/domain/vacation/dto/request/OptionalUserIdDto.java
+++ b/api/src/main/java/io/eagle/domain/vacation/dto/request/OptionalUserIdDto.java
@@ -1,0 +1,8 @@
+package io.eagle.domain.vacation.dto.request;
+
+import lombok.Data;
+
+@Data
+public class OptionalUserIdDto {
+    Long userId;
+}

--- a/api/src/main/java/io/eagle/domain/vacation/service/CahootsService.java
+++ b/api/src/main/java/io/eagle/domain/vacation/service/CahootsService.java
@@ -25,11 +25,10 @@ public class CahootsService {
 
     private final S3 s3;
 
-    public void create(CreateCahootsDto createCahootsDto) {
+    public void create(CreateCahootsDto createCahootsDto, User user) {
         createCahootsDto.validateCahootsPeriod();
-        // TODO : 요청 사용자의 정보 추가
         Vacation newVacation = createCahootsDto.buildVacation();
-        System.out.println(newVacation);
+        newVacation.setUser(user);
         if(!createCahootsDto.isImagesEmpty()) {
             List<Picture> pictureList = s3.getUrlsFromS3(createCahootsDto.getImages(), "VACATION");
             newVacation.setPictureList(pictureList);

--- a/api/src/main/java/io/eagle/domain/vacation/service/CahootsService.java
+++ b/api/src/main/java/io/eagle/domain/vacation/service/CahootsService.java
@@ -49,7 +49,7 @@ public class CahootsService {
     public List<BreifCahootsDto> getBreifList(InfoConditionDto infoConditionDto){
         List<BreifCahootsDto> breifCahootsList = vacationRepository.getVacationsBreif(infoConditionDto);
         Long userId = infoConditionDto.getUserId();
-        List<Long> myInterestVacation = (userId != null ? vacationRepository.findVacationIdByUserInterested(infoConditionDto.getUserId()) : List.of());
+        List<Long> myInterestVacation = (userId != null ? vacationRepository.findVacationIdByUserInterested(userId) : List.of());
         breifCahootsList.forEach(breifCahootsDto -> {
             breifCahootsDto.setImages(getImageUrls(breifCahootsDto.getId()));
             breifCahootsDto.setIsInterest(myInterestVacation.contains(breifCahootsDto.getId()));

--- a/api/src/main/java/io/eagle/domain/vacation/service/CahootsService.java
+++ b/api/src/main/java/io/eagle/domain/vacation/service/CahootsService.java
@@ -36,21 +36,20 @@ public class CahootsService {
         vacationRepository.save(newVacation);
     }
 
-    public DetailCahootsDto getDetail(Long cahootsId) {
+    public DetailCahootsDto getDetail(Long cahootsId, Long userId) {
         DetailCahootsDto detailCahootsDto = vacationRepository.getVacationDetail(cahootsId).checkNull();
         List<Interest> interests = interestRepository.findByVacation(vacationRepository.getReferenceById(cahootsId));
         detailCahootsDto.setInterestCount(interests.size());
-        // TODO : 사용자 정보 추가
-        Long userId = 1L;
-        detailCahootsDto.setIsInterest(interests.stream().map(Interest::getUser).map(User::getId).anyMatch(id -> id.equals(userId)));
+        Boolean isInterest = (userId != null ? interests.stream().map(Interest::getUser).map(User::getId).anyMatch(id -> id.equals(userId)) : false);
+        detailCahootsDto.setIsInterest(isInterest);
         detailCahootsDto.setImages(getImageUrls(cahootsId));
         return detailCahootsDto;
     }
 
     public List<BreifCahootsDto> getBreifList(InfoConditionDto infoConditionDto){
         List<BreifCahootsDto> breifCahootsList = vacationRepository.getVacationsBreif(infoConditionDto);
-        // TODO : 사용자 정보 추가
-        List<Long> myInterestVacation = vacationRepository.findVacationIdByUserInterested(1L);
+        Long userId = infoConditionDto.getUserId();
+        List<Long> myInterestVacation = (userId != null ? vacationRepository.findVacationIdByUserInterested(infoConditionDto.getUserId()) : List.of());
         breifCahootsList.forEach(breifCahootsDto -> {
             breifCahootsDto.setImages(getImageUrls(breifCahootsDto.getId()));
             breifCahootsDto.setIsInterest(myInterestVacation.contains(breifCahootsDto.getId()));

--- a/api/src/test/java/io/eagle/common/TestUtil.java
+++ b/api/src/test/java/io/eagle/common/TestUtil.java
@@ -55,7 +55,7 @@ public class TestUtil {
             .providerId("12354126646")
             .ranks(Ranks.NAMJAK)
             .role(Role.USER)
-            .cash(100)
+            .cash(100L)
             .build();
     }
 

--- a/api/src/test/java/io/eagle/domain/PriceInfo/repository/PriceInfoRepositoryTest.java
+++ b/api/src/test/java/io/eagle/domain/PriceInfo/repository/PriceInfoRepositoryTest.java
@@ -126,7 +126,7 @@ public class PriceInfoRepositoryTest {
             .providerId("12354126646")
             .ranks(Ranks.NAMJAK)
             .role(Role.USER)
-            .cash(100)
+            .cash(100L)
             .build();
     }
 

--- a/api/src/test/java/io/eagle/domain/vacation/service/CahootsServiceTest.java
+++ b/api/src/test/java/io/eagle/domain/vacation/service/CahootsServiceTest.java
@@ -56,7 +56,7 @@ public class CahootsServiceTest {
         contestParticipationRepository.save(new ContestParticipation(contributor, vacation, stocks));
 
         // when
-        DetailCahootsDto detailCahootsDto = cahootsService.getDetail(vacation.getId());
+        DetailCahootsDto detailCahootsDto = cahootsService.getDetail(vacation.getId(), contributor.getId());
 
         // then
         assertEquals(detailCahootsDto.getDescription(), vacation.getDescription());

--- a/core/src/main/java/io/eagle/entity/User.java
+++ b/core/src/main/java/io/eagle/entity/User.java
@@ -47,5 +47,5 @@ public class User {
     private String refreshToken;
 
     @Column
-    private Integer cash;
+    private Long cash;
 }

--- a/core/src/main/java/io/eagle/repository/UserRepository.java
+++ b/core/src/main/java/io/eagle/repository/UserRepository.java
@@ -2,6 +2,8 @@ package io.eagle.repository;
 
 import io.eagle.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -10,4 +12,8 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
     Optional<User> findByNickname(String nickname);
     Optional<User> findUserByProviderId(String providerId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE User u SET u.cash = ?2 WHERE u.id = ?1")
+    int updateCash(Long id, Long cash);
 }

--- a/socket/src/main/java/io/eagle/domain/order/controller/OrderController.java
+++ b/socket/src/main/java/io/eagle/domain/order/controller/OrderController.java
@@ -23,7 +23,7 @@ public class OrderController {
 
     @MessageMapping("/purchase") //   url : "order/purchase" 로 들어오는 정보 처리
     public void purchase(MessageDto message){
-        message.setRequesterId(1L); // TODO : 임시 사용자
+//        message.setRequesterId(1L); // TODO : 임시 사용자
         BroadcastMessageDto broadcastMessageDto = orderService.purchaseMarket(message);
         log.info("[STOMP Producer] user purchase market {} price : {}, amount : {}, left : {}",message.getMarketId(),message.getPrice(), message.getAmount(), broadcastMessageDto.getAmount());
         kafkaTemplate.send(KafkaConstants.KAFKA_TOPIC, broadcastMessageDto);

--- a/socket/src/main/java/io/eagle/domain/order/controller/OrderController.java
+++ b/socket/src/main/java/io/eagle/domain/order/controller/OrderController.java
@@ -23,7 +23,6 @@ public class OrderController {
 
     @MessageMapping("/purchase") //   url : "order/purchase" 로 들어오는 정보 처리
     public void purchase(MessageDto message){
-//        message.setRequesterId(1L); // TODO : 임시 사용자
         BroadcastMessageDto broadcastMessageDto = orderService.purchaseMarket(message);
         log.info("[STOMP Producer] user purchase market {} price : {}, amount : {}, left : {}",message.getMarketId(),message.getPrice(), message.getAmount(), broadcastMessageDto.getAmount());
         kafkaTemplate.send(KafkaConstants.KAFKA_TOPIC, broadcastMessageDto);

--- a/socket/src/main/java/io/eagle/domain/order/dto/request/MessageDto.java
+++ b/socket/src/main/java/io/eagle/domain/order/dto/request/MessageDto.java
@@ -7,6 +7,8 @@ import io.eagle.entity.type.OrderStatus;
 import io.eagle.entity.type.OrderType;
 import lombok.*;
 
+import javax.validation.constraints.NotNull;
+
 @Data
 public class MessageDto {
 
@@ -15,7 +17,9 @@ public class MessageDto {
     private Integer amount;
     private OrderType orderType;
 
+    @NotNull
     private Long requesterId;
+    private String token;
 
     public Order buildOrder(User user, Vacation vacation, Integer existingAmount, OrderStatus status){
         return Order.builder()

--- a/socket/src/main/java/io/eagle/domain/order/service/OrderService.java
+++ b/socket/src/main/java/io/eagle/domain/order/service/OrderService.java
@@ -13,6 +13,7 @@ import io.eagle.entity.type.OrderStatus;
 import io.eagle.entity.type.OrderType;
 import io.eagle.exception.SocketException;
 import io.eagle.repository.UserRepository;
+import io.eagle.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,6 +29,8 @@ public class OrderService {
     private final UserRepository userRepository;
     private final TransactionRepository transactionRepository;
     private final VacationRepository vacationRepository;
+
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
     public BroadcastMessageDto purchaseMarket(MessageDto message){
@@ -68,6 +71,12 @@ public class OrderService {
     }
 
     private void verifyMessage(MessageDto message){
+        try{
+            Long userId = jwtTokenProvider.getUserIdFromToken(message.getToken());
+            message.setRequesterId(userId);
+        } catch(Exception e){
+            throw new SocketException("요청자가 올바르지 않습니다.");
+        }
         if(message.getAmount() <= 0) throw new SocketException("요청 수량이 올바르지 않습니다.");
         if(message.getPrice() <= 0) throw new SocketException("요청 가격이 올바르지 않습니다.");
     }

--- a/socket/src/main/java/io/eagle/domain/order/service/OrderService.java
+++ b/socket/src/main/java/io/eagle/domain/order/service/OrderService.java
@@ -71,7 +71,7 @@ public class OrderService {
         if(message.getAmount() <= 0) throw new SocketException("요청 수량이 올바르지 않습니다.");
         if(message.getPrice() <= 0) throw new SocketException("요청 가격이 올바르지 않습니다.");
     }
-    private void verifyUserCash(Integer userCash, MessageDto message){
+    private void verifyUserCash(Long userCash, MessageDto message){
         Integer totalPrice = message.getPrice() * message.getAmount();
         if(totalPrice > userCash){// error handling
             throw new SocketException("사용자 캐시가 부족합니다");
@@ -79,7 +79,7 @@ public class OrderService {
     }
 
     private void subtractUserCash(User user, MessageDto message){
-        Integer leftCash = user.getCash() - (message.getAmount() * message.getPrice());
+        Long leftCash = user.getCash() - (message.getAmount() * message.getPrice());
         user.setCash(leftCash);
     }
     private Integer processOrdering(OrderType type, Integer requestAmount, Order purchaseOrder, Order saleOrder){


### PR DESCRIPTION
## 💬 Issue Number

> closes #82 

## 🤷‍♂️ Description

> 작업 내용에 대한 설명

Header Token 확인

- [x] : 공모 생성 시 사용자확인
- [x] : 공모 참여 시 사용자 확인 및 캐시 차감
- [x] : 주문 시 사용자 확인 및 캐시 차감 

북마크 정보는 Body에 user id로 전달

## 📷 Screenshots

> 작업 결과물

socket order에 사용자 token 전달 받지 못했을때 에러 처리

<img width="1186" alt="스크린샷 2023-02-25 오후 10 57 04" src="https://user-images.githubusercontent.com/34162358/221417308-1cbafb76-c3da-40db-8c1d-312d6c31a33d.png">


## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항

북마크 정보는 Body에 user id로 전달하는건 아까 프론트엔드 분들께 이야기해두었어요~!