### PR TITLE
Feat/#128 장소별 추천 휴양지 전달

### DIFF
--- a/api/src/main/java/io/eagle/domain/vacation/controller/MarketController.java
+++ b/api/src/main/java/io/eagle/domain/vacation/controller/MarketController.java
@@ -55,7 +55,6 @@ public class MarketController {
 
     @GetMapping("/markets/recommend")
     public ApiResponse getRankingPrice(String country, @RequestBody(required = false) OptionalUserIdDto user) {
-        System.out.println(country);
         return ApiResponse.createSuccess(marketService.getRecommendMarketByCountry(country, Utils.getUserId(user)));
     }
 }

--- a/api/src/main/java/io/eagle/domain/vacation/controller/MarketController.java
+++ b/api/src/main/java/io/eagle/domain/vacation/controller/MarketController.java
@@ -50,4 +50,10 @@ public class MarketController {
             )
         );
     }
+
+    @GetMapping("/markets/recommend")
+    public ApiResponse getRankingPrice(String country) {
+        System.out.println(country);
+        return ApiResponse.createSuccessWithNoContent();
+    }
 }

--- a/api/src/main/java/io/eagle/domain/vacation/controller/MarketController.java
+++ b/api/src/main/java/io/eagle/domain/vacation/controller/MarketController.java
@@ -1,6 +1,8 @@
 package io.eagle.domain.vacation.controller;
 
 import io.eagle.common.ApiResponse;
+import io.eagle.domain.vacation.common.Utils;
+import io.eagle.domain.vacation.dto.request.OptionalUserIdDto;
 import io.eagle.domain.vacation.service.MarketService;
 import io.eagle.entity.type.MarketRankingType;
 import lombok.RequiredArgsConstructor;
@@ -52,8 +54,8 @@ public class MarketController {
     }
 
     @GetMapping("/markets/recommend")
-    public ApiResponse getRankingPrice(String country) {
+    public ApiResponse getRankingPrice(String country, @RequestBody(required = false) OptionalUserIdDto user) {
         System.out.println(country);
-        return ApiResponse.createSuccessWithNoContent();
+        return ApiResponse.createSuccess(marketService.getRecommendMarketByCountry(country, Utils.getUserId(user)));
     }
 }

--- a/api/src/main/java/io/eagle/domain/vacation/dto/response/RecommendMarketDto.java
+++ b/api/src/main/java/io/eagle/domain/vacation/dto/response/RecommendMarketDto.java
@@ -1,0 +1,18 @@
+package io.eagle.domain.vacation.dto.response;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class RecommendMarketDto {
+    private Long id;
+    private String title;
+    private Integer expectedRateOfReturn;
+
+    private String image;
+    private Boolean isInterest;
+}

--- a/api/src/main/java/io/eagle/domain/vacation/repository/VacationCustom.java
+++ b/api/src/main/java/io/eagle/domain/vacation/repository/VacationCustom.java
@@ -19,4 +19,6 @@ public interface VacationCustom {
     List<ImminentInfoDto> findByImminentEndVacation();
     List<String> getCountries(VacationStatusType type);
     MarketRankDto findMarketRankInfoById(Long id);
+
+    RecommendMarketDto getRecommendMarket(Long vacationId, Long userId);
 }

--- a/api/src/main/java/io/eagle/domain/vacation/repository/VacationCustomImpl.java
+++ b/api/src/main/java/io/eagle/domain/vacation/repository/VacationCustomImpl.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import static io.eagle.entity.QContestParticipation.contestParticipation;
 import static io.eagle.entity.QInterest.interest;
+import static io.eagle.entity.QPicture.picture;
 import static io.eagle.entity.QVacation.vacation;
 
 @RequiredArgsConstructor
@@ -185,6 +186,23 @@ public class VacationCustomImpl implements VacationCustom {
 
         List<MarketQueryVO> marketQueryVO = jpaResultMapper.list(query, MarketQueryVO.class);
         return marketQueryVO.size() == 0 ? null : new MarketRankDto(marketQueryVO.get(0));
+    }
+
+    public RecommendMarketDto getRecommendMarket(Long vacationId, Long userId){
+        // select vacation.id, vacation.title , vacation.expectedRateOfReturn, picture.url, interest.me
+        return queryFactory
+                .select(Projections.fields(RecommendMarketDto.class,
+                        vacation.id,
+                        vacation.title,
+                        vacation.expectedRateOfReturn,
+                        picture.url.as("image"),
+                        interest.isNotNull().as("isInterest")
+                ))
+                .from(vacation)
+                .where(vacation.id.eq(vacationId))
+                .leftJoin(picture)
+                .leftJoin(interest).on(interest.user.id.eq(userId))
+                .fetchOne();
     }
 
     private BooleanExpression isInStatus(VacationStatusType[] statusTypes){

--- a/api/src/main/java/io/eagle/domain/vacation/service/CahootsService.java
+++ b/api/src/main/java/io/eagle/domain/vacation/service/CahootsService.java
@@ -14,7 +14,10 @@ import io.eagle.domain.vacation.repository.VacationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
 import java.util.List;
 
 import static io.eagle.entity.type.MarketRankingType.CountryKey;
@@ -28,11 +31,17 @@ public class CahootsService {
     private final PictureRepository pictureRepository;
     private final InterestRepository interestRepository;
     private final RedisTemplate<String, String> redisTemplate;
+    private ZSetOperations<String, String> redisZSet;
 
     private final S3 s3;
 
     @Value("${eagle.score.view}")
     private Integer viewScore;
+
+    @PostConstruct
+    public void init(){
+        this.redisZSet = redisTemplate.opsForZSet();
+    }
 
     public void create(CreateCahootsDto createCahootsDto, User user) {
         createCahootsDto.validateCahootsPeriod();
@@ -90,7 +99,7 @@ public class CahootsService {
     }
 
     private void incrementInterestMarketScore(String key, String value, Integer score){
-        redisTemplate.opsForZSet().incrementScore(key, value, (double) score);
+        redisZSet.incrementScore(key, value, (double) score);
     }
 
 

--- a/api/src/main/java/io/eagle/domain/vacation/service/MarketService.java
+++ b/api/src/main/java/io/eagle/domain/vacation/service/MarketService.java
@@ -19,6 +19,7 @@ import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.annotation.PostConstruct;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -37,6 +38,12 @@ public class MarketService {
     private final PictureRepository pictureRepository;
     private final InterestRepository interestRepository;
     private final RedisTemplate<String, String> redisTemplate;
+    private ZSetOperations<String, String> redisZSet;
+
+    @PostConstruct
+    public void init(){
+        this.redisZSet = redisTemplate.opsForZSet();
+    }
 
     public List<MarketListDto> getAllMarkets(Pageable pageable) {
         return vacationRepository.findAllMarkets(pageable).stream().map(vacation -> {
@@ -125,11 +132,10 @@ public class MarketService {
     }
 
     private Set<String> findMarketRankInRedis(String key, Boolean upOrDown) {
-        ZSetOperations<String, String> zSetOperations = redisTemplate.opsForZSet();
         if (upOrDown) {
-            return zSetOperations.reverseRange(key, 0, 5);
+            return redisZSet.reverseRange(key, 0, 5);
         }
-        return zSetOperations.range(key, 0, 5);
+        return redisZSet.range(key, 0, 5);
     }
 
     private MarketRankDto findMarketRankInfoById(Long id) {

--- a/api/src/main/java/io/eagle/domain/vacation/service/MarketService.java
+++ b/api/src/main/java/io/eagle/domain/vacation/service/MarketService.java
@@ -3,10 +3,7 @@ package io.eagle.domain.vacation.service;
 import io.eagle.domain.interest.repository.InterestRepository;
 import io.eagle.domain.picture.repository.PictureRepository;
 import io.eagle.domain.transaction.repository.TransactionRepository;
-import io.eagle.domain.vacation.dto.response.MarketDetailDto;
-import io.eagle.domain.vacation.dto.response.MarketInfoDto;
-import io.eagle.domain.vacation.dto.response.MarketListDto;
-import io.eagle.domain.vacation.dto.response.MarketRankDto;
+import io.eagle.domain.vacation.dto.response.*;
 import io.eagle.domain.vacation.repository.VacationRepository;
 import io.eagle.entity.type.MarketRankingType;
 import io.eagle.entity.Picture;
@@ -27,6 +24,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static io.eagle.entity.type.MarketRankingType.CountryKey;
 
 @Service
 @RequiredArgsConstructor
@@ -115,6 +114,14 @@ public class MarketService {
                 Long.parseLong(Objects.requireNonNull(e)))
             )
             .collect(Collectors.toList());
+    }
+
+    public List<RecommendMarketDto> getRecommendMarketByCountry(String country, Long userId){
+        String key = CountryKey(country);
+        return this.findMarketRankInRedis(key, true)
+                .stream()
+                .map(e -> vacationRepository.getRecommendMarket(Long.parseLong(Objects.requireNonNull(e)), userId))
+                .collect(Collectors.toList());
     }
 
     private Set<String> findMarketRankInRedis(String key, Boolean upOrDown) {

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -5,7 +5,3 @@ spring:
       - mysql
       - oauth
       - cloud
-
-eagle:
-  score:
-    view: 1

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -5,3 +5,7 @@ spring:
       - mysql
       - oauth
       - cloud
+
+eagle:
+  score:
+    view: 1

--- a/core/src/main/java/io/eagle/entity/type/MarketRankingType.java
+++ b/core/src/main/java/io/eagle/entity/type/MarketRankingType.java
@@ -7,7 +7,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MarketRankingType {
     PRICE("PRICE"),
-    PRICE_RATE("PRICE_RATE");
+    PRICE_RATE("PRICE_RATE"),
+
+    COUNTRY("COUNTRY");
 
     private final String key;
+
+    public static String CountryKey(String country){
+        return COUNTRY + "-" + country;
+    }
 }

--- a/core/src/main/resources/application-core.yml
+++ b/core/src/main/resources/application-core.yml
@@ -26,3 +26,6 @@ eagle:
     page : 10
     before_day : 30
     recent_day : 100
+  score:
+    view: 1
+    order: 5


### PR DESCRIPTION
## 💬 Issue Number

> closes #128

## 🤷‍♂️ Description

> 작업 내용에 대한 설명

### end point
`{{ip}}:{{port}}/api/markets/recommend?country={나라이름}`

### 추천 score 산정
- 상세 정보 조회 1건 : 1점
- 주문 수량 N건 : 5*N점

### 체크리스트

- [x] : 마켓 오픈 된 휴양지 상세 조회시 점수 증가
- [x] : 마켓 주문 시 점수 증가
- [x] : 나라 별로 인기 점수치로 추천 휴양지 정보 전달

## 📷 Screenshots

> 작업 결과물

id 1 : 63점, id 50 : 10점

<img width="309" alt="스크린샷 2023-03-01 오전 1 11 12" src="https://user-images.githubusercontent.com/34162358/221911561-2d6c741c-c7be-4e85-989c-7b1a95ca683c.png">


<img width="351" alt="스크린샷 2023-03-01 오전 1 10 53" src="https://user-images.githubusercontent.com/34162358/221911553-52f6b831-9b1f-499e-95b3-d583f98de761.png">



## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항

score가 전부 key-value가 <String, String> 형식으로 되어있어서 sorted set을 하나로 관리하고,
이후 다른 자료형을 redis에 저장하게 되면 그것도 하나의 component에서 관리하려고 작성했다가,
그럴거면 처음부터 redis repository를 써야하는거 아닌가.. 생각해서
그냥 sorted set을 class별로 관리하는 변수를 따로 빼서, redis template 의존성 주입 후에 생성되도록 변경했습니다.

intelliJ redis plugin 깔았는데 좋네용!