### PR TITLE
Fix/#148 추천 휴양지 점수 누적 위치 변경

### DIFF
--- a/api/src/main/java/io/eagle/domain/vacation/service/CahootsService.java
+++ b/api/src/main/java/io/eagle/domain/vacation/service/CahootsService.java
@@ -30,18 +30,8 @@ public class CahootsService {
     private final VacationRepository vacationRepository;
     private final PictureRepository pictureRepository;
     private final InterestRepository interestRepository;
-    private final RedisTemplate<String, String> redisTemplate;
-    private ZSetOperations<String, String> redisZSet;
 
     private final S3 s3;
-
-    @Value("${eagle.score.view}")
-    private Integer viewScore;
-
-    @PostConstruct
-    public void init(){
-        this.redisZSet = redisTemplate.opsForZSet();
-    }
 
     public void create(CreateCahootsDto createCahootsDto, User user) {
         createCahootsDto.validateCahootsPeriod();
@@ -61,9 +51,6 @@ public class CahootsService {
         Boolean isInterest = (userId != null ? interests.stream().map(Interest::getUser).map(User::getId).anyMatch(id -> id.equals(userId)) : false);
         detailCahootsDto.setIsInterest(isInterest);
         detailCahootsDto.setImages(getImageUrls(cahootsId));
-        if(detailCahootsDto.getStatus().equals(MARKET_ONGOING)){
-            this.incrementInterestMarketScore(CountryKey(detailCahootsDto.getCountry()), detailCahootsDto.getId().toString(), viewScore);
-        }
         return detailCahootsDto;
     }
 
@@ -96,10 +83,6 @@ public class CahootsService {
 
     public List<String> getImageUrls(Long id){
         return pictureRepository.findUrlsByCahootsId(id);
-    }
-
-    private void incrementInterestMarketScore(String key, String value, Integer score){
-        redisZSet.incrementScore(key, value, (double) score);
     }
 
 

--- a/api/src/main/java/io/eagle/exception/error/ErrorCode.java
+++ b/api/src/main/java/io/eagle/exception/error/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     // Vacation
     VACATION_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 공모 ID 입니다."),
     VACATION_PERIOD_INVALID(HttpStatus.BAD_REQUEST,"공모 기간이 올바르지 않습니다."),
+    VACATION_IS_NOT_MARKET(HttpStatus.BAD_REQUEST, "해당 휴양지는 마켓 진행 중이 아닙니다."),
 
     // Order
 


### PR DESCRIPTION
## 💬 Issue Number

> closes #148

## 🤷‍♂️ Description

> 작업 내용에 대한 설명

AS-IS : 마켓, 공모 공통 service function 사용한다고 가정하고 cahoots service에 점수가 올라가는 로직 수행
TO-BE : 마켓에 해당하는 service function에서만 점수 카운팅 하도록 변경

## 📷 Screenshots

> 작업 결과물

조회 전

<img width="704" alt="image" src="https://user-images.githubusercontent.com/34162358/222715943-0681c73f-9b00-43db-a7eb-538aac5eabb4.png">

`{{ip}}:{{port}}/api/markets/76` 조회 후

<img width="672" alt="image" src="https://user-images.githubusercontent.com/34162358/222716305-da5b49ac-4d80-40dc-a8ae-1e5615954956.png">


## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항

마켓 조회 시 findById로 하고있어 마켓 진행 중인지에 대한 검증 로직이 없어 추가하였습니다.

<img width="558" alt="image" src="https://user-images.githubusercontent.com/34162358/222715794-c27fe195-ed03-42eb-993b-8f66c634a4b0.png">

<img width="555" alt="image" src="https://user-images.githubusercontent.com/34162358/222716147-2fa6cffa-3f9e-42ce-a9f0-dc9a78332365.png">

