### PR TITLE
Setting/#161 Redis replication 적용

### DIFF
--- a/settings/README.md
+++ b/settings/README.md
@@ -14,8 +14,8 @@ $ docker-compose exec kafka kafka-topics --describe --topic kafka-market --boots
 ## Redis docker 설정
 
 ```shell
-$ docker pull redis:alpine
-$ docker run --name redis -p 6379:6379 -v /home/ubuntu/redis_data:/data -d redis --requirepass {password}
+$ export REDIS_PASSWORD=비밀번호
+$ docker-compose -f docker-compose-redis.yml up -d
 $ docker exec -it redis redis-cli -a {password} # redis-cli로 접속하기
 ```
 

--- a/settings/docker-compose-redis.yml
+++ b/settings/docker-compose-redis.yml
@@ -3,7 +3,8 @@ version: '2'
 services:
   redis-master:
     image: redis:alpine
-    command: redis-server --requirepass ${REDIS_PASSWORD} --appendonly no
+    container_name: redis-master
+    command: redis-server  --requirepass ${REDIS_PASSWORD} --appendonly no
     volumes:
       - /home/ubuntu/redis_data/master:/data
     ports:
@@ -12,12 +13,14 @@ services:
       - wm-net
     environment:
       - REDIS_PASSWORD=${REDIS_PASSWORD}
+      - REDIS_REPLICATION_MODE=master
     restart: always
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
   redis-slave:
     image: redis:alpine
+    container_name: redis-slave
     command: redis-server --slaveof redis-master 6379 --requirepass ${REDIS_PASSWORD} --appendonly no
     volumes:
       - /home/ubuntu/redis_data/slave:/data
@@ -27,6 +30,7 @@ services:
       - wm-net
     environment:
       - REDIS_PASSWORD=${REDIS_PASSWORD}
+      - REDIS_REPLICATION_MODE=slave
     restart: always
 
 networks:

--- a/settings/docker-compose-redis.yml
+++ b/settings/docker-compose-redis.yml
@@ -1,0 +1,34 @@
+version: '2'
+
+services:
+  redis-master:
+    image: redis:alpine
+    command: redis-server --requirepass ${REDIS_PASSWORD} --appendonly no
+    volumes:
+      - /home/ubuntu/redis_data/master:/data
+    ports:
+      - "6379:6379"
+    networks:
+      - wm-net
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
+    restart: always
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  redis-slave:
+    image: redis:alpine
+    command: redis-server --slaveof redis-master 6379 --requirepass ${REDIS_PASSWORD} --appendonly no
+    volumes:
+      - /home/ubuntu/redis_data/slave:/data
+    ports:
+      - "6380:6379"
+    networks:
+      - wm-net
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
+    restart: always
+
+networks:
+  wm-net:
+    driver: bridge


### PR DESCRIPTION
## 💬 Issue Number

> closes #161

## 🤷‍♂️ Description

> 작업 내용에 대한 설명

지난주에 제안해주신 Redis 운영관련해서 실제로 적용해봤습니다.
Cluster나 Sentinel를 적용하면 좋겠지만, 학습까지 하고 실제 운용은 Replication 방식만 적용했습니다.

[운용 설계 관련 글 작성](https://jinsungone.notion.site/Redis-5f1df17a8a01486799385e499908be83)

## 📷 Screenshots

> 작업 결과물

<img width="889" alt="image" src="https://user-images.githubusercontent.com/34162358/224241357-78dbbd67-06e6-4e64-b770-cef81f7855ca.png">


## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항


서버에 새로 추가한 docker-compose로 redis 운용해두었습니다.
EC2 인스턴스를 2대 사용하면 프리티어 사용 시간을 절반으로 줄여야하기 때문에, 계속 사용 중인 인스턴스에 2대를 운용했습니다.