### PR TITLE
Feat/#167 주문 대기 리스트 전달

### DIFF
--- a/.github/workflows/BATCH_CD.yml
+++ b/.github/workflows/BATCH_CD.yml
@@ -69,3 +69,11 @@ jobs:
             sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/wm-batch-server:${GITHUB_SHA::7}
             docker run -d -p 8081:8081 --name wm-batch-server --add-host host.docker.internal:host-gateway ${{ secrets.DOCKERHUB_USERNAME }}/wm-batch-server:${GITHUB_SHA::7}
             docker image prune -af
+
+      - name: Discord notification
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        uses: Ilshidur/action-discord@master
+        with:
+          args: 'Deploy BATCH ${{ job.status }} [${{ github.event.pull_request.title }}] - wealth marble'
+        if: always()

--- a/.github/workflows/SOCKET_CD.yml
+++ b/.github/workflows/SOCKET_CD.yml
@@ -69,16 +69,6 @@ jobs:
             docker run -d -p 7070:8080 --name wm-socket-server --add-host host.docker.internal:host-gateway ${{ secrets.DOCKERHUB_USERNAME }}/wm-socket-server:${GITHUB_SHA::7}
             docker image prune -af
 
-#      - name: Slack Deploy bot 실행
-#        uses: 8398a7/action-slack@v3
-#        with:
-#          status: ${{ job.status }}
-#          author_name: Backend Deploy Success
-#          fields: repo,commit,message,author
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_DEPLOY_URL }}
-#        if: always()
-
       - name: Discord notification
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}

--- a/api/src/main/java/io/eagle/domain/order/controller/OrderController.java
+++ b/api/src/main/java/io/eagle/domain/order/controller/OrderController.java
@@ -1,0 +1,21 @@
+package io.eagle.domain.order.controller;
+
+import io.eagle.common.ApiResponse;
+import io.eagle.domain.order.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/orders")
+@RequiredArgsConstructor
+public class OrderController {
+    private final OrderService orderService;
+
+    @GetMapping("/{vacationId}/list")
+    public ApiResponse getTransactionAvailableList(@PathVariable("vacationId") Long vacationId){
+        return ApiResponse.createSuccess(orderService.getOrderList(vacationId));
+    }
+}

--- a/api/src/main/java/io/eagle/domain/order/dto/response/AvailableOrderDto.java
+++ b/api/src/main/java/io/eagle/domain/order/dto/response/AvailableOrderDto.java
@@ -1,0 +1,11 @@
+package io.eagle.domain.order.dto.response;
+
+import io.eagle.entity.type.OrderType;
+import lombok.Getter;
+
+@Getter
+public class AvailableOrderDto {
+    public Integer price;
+    public Integer amount;
+    public OrderType orderType;
+}

--- a/api/src/main/java/io/eagle/domain/order/repository/OrderRepositoryCustom.java
+++ b/api/src/main/java/io/eagle/domain/order/repository/OrderRepositoryCustom.java
@@ -1,12 +1,15 @@
 package io.eagle.domain.order.repository;
 
+import io.eagle.domain.order.dto.response.AvailableOrderDto;
 import io.eagle.entity.Order;
+import io.eagle.entity.Transaction;
 import io.eagle.entity.User;
+import io.eagle.entity.type.OrderType;
 
 import java.util.List;
 
 public interface OrderRepositoryCustom {
 
     List<Order> findAllByUser(User user);
-
+    List<AvailableOrderDto> findTop5ByVacationIdAndOrderTypeOrderByPrice(Long id, OrderType type);
 }

--- a/api/src/main/java/io/eagle/domain/order/repository/OrderRepositoryImpl.java
+++ b/api/src/main/java/io/eagle/domain/order/repository/OrderRepositoryImpl.java
@@ -1,11 +1,16 @@
 package io.eagle.domain.order.repository;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPQLQueryFactory;
+import io.eagle.domain.order.dto.response.AvailableOrderDto;
 import io.eagle.entity.Order;
 import io.eagle.entity.User;
+import io.eagle.entity.type.OrderType;
 import lombok.RequiredArgsConstructor;
 
 import static io.eagle.entity.QOrder.order;
+import static io.eagle.entity.type.OrderStatus.ONGOING;
+import static io.eagle.entity.type.OrderType.SELL;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,5 +28,21 @@ public class OrderRepositoryImpl implements OrderRepositoryCustom {
             .fetchAll()
             .stream()
             .collect(Collectors.toList());
+    }
+
+
+    public List<AvailableOrderDto> findTop5ByVacationIdAndOrderTypeOrderByPrice(Long id, OrderType type){
+        return jpqlQueryFactory
+                .select(Projections.fields(AvailableOrderDto.class,
+                        order.price,
+                        order.amount.sum().as("amount"),
+                        order.orderType))
+                .from(order)
+                .where( order.status.eq(ONGOING))
+                .groupBy(order.vacation, order.price)
+                .having(order.vacation.id.eq(id), order.orderType.eq(type))
+                .orderBy((type == SELL ? order.price.asc() : order.price.desc()))
+                .limit(5)
+                .fetch();
     }
 }

--- a/api/src/main/java/io/eagle/domain/order/service/OrderService.java
+++ b/api/src/main/java/io/eagle/domain/order/service/OrderService.java
@@ -1,0 +1,30 @@
+package io.eagle.domain.order.service;
+
+import io.eagle.domain.order.dto.response.AvailableOrderDto;
+import io.eagle.domain.order.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static io.eagle.entity.type.OrderType.BUY;
+import static io.eagle.entity.type.OrderType.SELL;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+    private final OrderRepository orderRepository;
+
+    public List<AvailableOrderDto> getOrderList(Long vacationId){
+        List<AvailableOrderDto> result = orderRepository.findTop5ByVacationIdAndOrderTypeOrderByPrice(vacationId, SELL)
+                .stream()
+                .sorted(Comparator.comparing(AvailableOrderDto::getPrice).reversed())
+                .collect(Collectors.toList());
+        List<AvailableOrderDto> result2 = orderRepository.findTop5ByVacationIdAndOrderTypeOrderByPrice(vacationId, BUY);
+        result.addAll(result2);
+        return result;
+    }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ subprojects {
 	dependencies {
 		implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 		implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-		implementation 'org.redisson:redisson-spring-boot-starter:3.17.4'
+//		implementation 'org.redisson:redisson-spring-boot-starter:3.17.4'
 		implementation 'org.springframework.boot:spring-boot-starter-security'
 		implementation 'org.springframework.boot:spring-boot-starter-validation'
 		implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/core/src/main/java/io/eagle/config/RedisConfig.java
+++ b/core/src/main/java/io/eagle/config/RedisConfig.java
@@ -1,8 +1,8 @@
 package io.eagle.config;
 
-import org.redisson.Redisson;
-import org.redisson.api.RedissonClient;
-import org.redisson.config.Config;
+//import org.redisson.Redisson;
+//import org.redisson.api.RedissonClient;
+//import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;


### PR DESCRIPTION
## 💬 Issue Number

> closes #167

## 🤷‍♂️ Description

> 작업 내용에 대한 설명

`{{ip}}:{{port}}/api/orders/:vacationId/list`

마켓 상세 페이지에서 주문 대기 리스트에 필요한 리스트를 전달하는 API 작성했습니다.

![image](https://user-images.githubusercontent.com/34162358/225308037-5db213c3-e071-47d9-b822-69609c8d63da.png)


- [x] : 판매 주문 최하위 가격 최대 5개 전달
- [x] : 구매 주문 최상위 가격 최대 5개 전달
- [x] : controller, service, repository, dto 작성

## 📷 Screenshots

> 작업 결과물

<img width="252" alt="image" src="https://user-images.githubusercontent.com/34162358/225307496-d376f44e-0b90-4574-8f80-c2dd3f31b3c3.png">

## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?
