### PR TITLE
Hotfix : 구매 요청 시 더이상 수량이 없으면 0 반환

### DIFF
--- a/socket/src/main/java/io/eagle/domain/order/service/OrderService.java
+++ b/socket/src/main/java/io/eagle/domain/order/service/OrderService.java
@@ -81,12 +81,12 @@ public class OrderService {
 
         //   해당 가격의 수량 확인해서 전달
         TotalMountDto leftAmount = orderRepository.getCurrentOrderAmount(message.getMarketId(),message.getPrice(), message.getOrderType());
-        log.debug(leftAmount.toString());
+        log.debug(leftAmount != null ? leftAmount.toString(): "No left any more sell done!");
         return BroadcastStockDto.builder()
                 .marketId(message.getMarketId())
                 .price(message.getPrice())
-                .amount(leftAmount.getAmount())
-                .orderType(leftAmount.getType())
+                .amount(leftAmount != null ? leftAmount.getAmount() : 0)
+                .orderType(leftAmount != null ? leftAmount.getType() : message.getOrderType())
                 .build();
     }
 


### PR DESCRIPTION
## 💬 Issue Number

> Hotfix로 이슈 생성하지 않음

## 🤷‍♂️ Description

> 작업 내용에 대한 설명

상황 : 마켓 지분 구매 요청 시
에러 발생 케이스 : 잔여 수량 만큼 구매 했을 때, 해당 가격에 남은 거래 가능 수량이 0이면 null point exception 발생
해결 : null일 때 0을 return 하도록 변경

## 📷 Screenshots

> 작업 결과물

![image](https://user-images.githubusercontent.com/34162358/225881956-9fd3edf3-40c1-400b-b6f9-957848f814bd.png)

