### PR TITLE
Bug/#182 일간 거래량 통계 정보 관련 버그 수정

### DIFF
--- a/batch/src/main/java/io/eagle/chunk/processor/CopyPriceInfoProcessor.java
+++ b/batch/src/main/java/io/eagle/chunk/processor/CopyPriceInfoProcessor.java
@@ -3,18 +3,22 @@ package io.eagle.chunk.processor;
 import io.eagle.domain.PriceInfoVO;
 import io.eagle.entity.PriceInfo;
 import io.eagle.entity.Vacation;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.item.ItemProcessor;
 
+@Slf4j
 public class CopyPriceInfoProcessor implements ItemProcessor<PriceInfoVO, PriceInfo> {
 
     @Override
     public PriceInfo process(PriceInfoVO lastPriceInfo) throws Exception {
+        log.debug("Vacation that didn't trade yesterday : " + lastPriceInfo.getVacationId());
         return PriceInfo.builder()
                 .vacation(Vacation.builder().id(lastPriceInfo.getVacationId()).build())
                 .highPrice(lastPriceInfo.getStandardPrice())
                 .lowPrice(lastPriceInfo.getStandardPrice())
                 .standardPrice(lastPriceInfo.getStandardPrice())
                 .startPrice(lastPriceInfo.getStandardPrice())
+                .createdAt(lastPriceInfo.getCreatedAt().plusDays(1))
                 .transactionAmount(0)
                 .transactionMoney(0)
                 .build();

--- a/batch/src/main/java/io/eagle/chunk/processor/CreateStockProcessor.java
+++ b/batch/src/main/java/io/eagle/chunk/processor/CreateStockProcessor.java
@@ -62,7 +62,7 @@ public class CreateStockProcessor implements ItemProcessor<Vacation, List<Stock>
 
     private List<ContestParticipation> findAllContestParticipationByVacation(Long vacationId) {
         return jdbcTemplate.query(
-            "select * from contest_participation where vacation_id = ?",
+            "select * from contest_participation as c where c.cahoots_id = ?",
             new BeanPropertyRowMapper<>(ContestParticipation.class),
             vacationId
         );

--- a/batch/src/main/java/io/eagle/chunk/processor/InitPriceInfoProcessor.java
+++ b/batch/src/main/java/io/eagle/chunk/processor/InitPriceInfoProcessor.java
@@ -1,0 +1,26 @@
+package io.eagle.chunk.processor;
+
+import io.eagle.domain.PriceInfoVO;
+import io.eagle.entity.PriceInfo;
+import io.eagle.entity.Vacation;
+import org.springframework.batch.item.ItemProcessor;
+
+import java.time.LocalDateTime;
+
+public class InitPriceInfoProcessor implements ItemProcessor<Vacation, PriceInfo> {
+
+    @Override
+    public PriceInfo process(Vacation vacation) throws Exception {
+        return PriceInfo.builder()
+                .vacation(Vacation.builder().id(vacation.getId()).build())
+                .highPrice(vacation.getStock().getPrice().intValue())
+                .lowPrice(vacation.getStock().getPrice().intValue())
+                .standardPrice(vacation.getStock().getPrice().intValue())
+                .startPrice(vacation.getStock().getPrice().intValue())
+                .createdAt(LocalDateTime.now().minusDays(1L))
+                .transactionAmount(0)
+                .transactionMoney(0)
+                .build();
+    }
+}
+

--- a/batch/src/main/java/io/eagle/chunk/processor/PriceInfoProcessor.java
+++ b/batch/src/main/java/io/eagle/chunk/processor/PriceInfoProcessor.java
@@ -3,12 +3,16 @@ package io.eagle.chunk.processor;
 import io.eagle.domain.PriceInfoVO;
 import io.eagle.entity.PriceInfo;
 import io.eagle.entity.Vacation;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.item.ItemProcessor;
+
+@Slf4j
 
 public class PriceInfoProcessor implements ItemProcessor<PriceInfoVO, PriceInfo> {
 
     @Override
     public PriceInfo process(PriceInfoVO lastPriceInfo) throws Exception {
+        log.debug("Vacation that traded yesterday : " + lastPriceInfo.getVacationId());
         return PriceInfo.builder()
                 .vacation(Vacation.builder().id(lastPriceInfo.getVacationId()).build())
                 .highPrice(lastPriceInfo.getHighPrice())
@@ -17,6 +21,7 @@ public class PriceInfoProcessor implements ItemProcessor<PriceInfoVO, PriceInfo>
                 .startPrice(lastPriceInfo.getStartPrice())
                 .transactionAmount(lastPriceInfo.getTransactionAmount())
                 .transactionMoney(lastPriceInfo.getTransactionMoney())
+                .createdAt(lastPriceInfo.getCreatedAt())
                 .build();
     }
 }

--- a/batch/src/main/java/io/eagle/common/BatchConstant.java
+++ b/batch/src/main/java/io/eagle/common/BatchConstant.java
@@ -18,4 +18,8 @@ public final class BatchConstant {
 
     public static final String RECENT_TRANSACTION_JOB = "recentTransactionJob";
     public static final String RECENT_TRANSACTION_STEP = "recentTransactionStep";
+
+    public static final String INIT_PRICE_INFO_JOB = "initiatePriceInfoJob";
+    public static final String INIT_PRICE_INFO_STEP = "initiatePriceInfoStep";
+    public static final String INIT_PRICE_INFO_READER = "initiatePriceInfoItemReader";
 }

--- a/batch/src/main/java/io/eagle/domain/PriceInfoVO.java
+++ b/batch/src/main/java/io/eagle/domain/PriceInfoVO.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 
 @Data
 @Builder
@@ -13,6 +15,7 @@ import lombok.NoArgsConstructor;
 public class PriceInfoVO {
 
     private Long vacationId;
+    private LocalDateTime createdAt;
     private Integer startPrice;
     private Integer highPrice;
     private Integer lowPrice;

--- a/batch/src/main/java/io/eagle/job/PriceInfoJobConfig.java
+++ b/batch/src/main/java/io/eagle/job/PriceInfoJobConfig.java
@@ -58,7 +58,7 @@ public class PriceInfoJobConfig {
         return stepBuilderFactory.get(TRANSACTIONS_SUMMARY_STEP)
                 .<PriceInfoVO, PriceInfo>chunk(CHUNK_SIZE)
                 .reader(transactionsSummaryItemReader())
-                .processor(transactionsSummaryItemProcessor())
+                .processor(new PriceInfoProcessor())
                 .writer(transactionsSummaryItemWriter())
                 .listener(new CustomStepExecutionListener())
                 .build();
@@ -81,11 +81,6 @@ public class PriceInfoJobConfig {
                 .beanRowMapper(PriceInfoVO.class)
                 .build();
     }
-    @Bean(TRANSACTIONS_SUMMARY_STEP + "_processor")
-    @StepScope
-    public ItemProcessor<PriceInfoVO, PriceInfo> transactionsSummaryItemProcessor() {
-        return new PriceInfoProcessor();
-    }
 
     @Bean(TRANSACTIONS_SUMMARY_STEP + "_writer")
     @StepScope
@@ -101,7 +96,7 @@ public class PriceInfoJobConfig {
         return stepBuilderFactory.get(TRANSFER_LASTDAY_PRICEINFO_STEP)
                 .<PriceInfoVO, PriceInfo>chunk(CHUNK_SIZE)
                 .reader(transferLastdayPriceInfoItemReader())
-                .processor(transferLastdayPriceInfoItemProcessor())
+                .processor(new CopyPriceInfoProcessor())
                 .writer(transferLastdayPriceInfoItemWriter())
                 .listener(new CustomStepExecutionListener())
                 .build();
@@ -125,11 +120,6 @@ public class PriceInfoJobConfig {
                 .build();
     }
 
-    @Bean(TRANSFER_LASTDAY_PRICEINFO_STEP + "_processor")
-    @StepScope
-    public ItemProcessor<PriceInfoVO, PriceInfo> transferLastdayPriceInfoItemProcessor() {
-        return new CopyPriceInfoProcessor();
-    }
 
     @Bean(TRANSFER_LASTDAY_PRICEINFO_STEP + "_writer")
     @StepScope

--- a/core/src/main/java/io/eagle/entity/PriceInfo.java
+++ b/core/src/main/java/io/eagle/entity/PriceInfo.java
@@ -3,6 +3,7 @@ package io.eagle.entity;
 import lombok.*;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -19,6 +20,9 @@ public class PriceInfo extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "vacation_id")
     private Vacation vacation;
+
+    @Column
+    private LocalDateTime createdAt;
 
     @Column
     private Integer startPrice;


### PR DESCRIPTION
## 💬 Issue Number

> closes #182

## 🤷‍♂️ Description

> 작업 내용에 대한 설명

오늘이 A일, 통계를 내는 전날을 B라고 하면

- [x] 날짜 오류 : Price Info의 createdAt 날짜를 생성일 A로 되어있어 B로 수정
- [x] processor 미구동 오류 : stepScope의 경우 구체화 class를 전달하지 않으면 interface의 proxy 객체를 전달함 [참고](https://jojoldu.tistory.com/132)
- [x] 거래가 없을 때 price info 가 생성되지 않는 경우 : 마켓 전환 시 price info 초기 데이터 생성

> 주식 배분 시 수행하는 query에서 오류가 보여서 이부분은 수정했습니다. 수정 후에 다시 확인 해보니 주식 배분이 이루어지긴 하는데 stock  table에 저장되는 부분이 제대로 이루어지지 않고 있어 이부분 확인해서 수정부탁드립니다.
 
## 📷 Screenshots

> 작업 결과물

![image](https://user-images.githubusercontent.com/34162358/229342401-9ba2c314-ece4-48fe-b7e0-f4c43b2dad2c.png)


## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?
