### PR TITLE
Fix/#193 vacation transition job에서 User NULL 오류 수정

### DIFF
--- a/batch/src/main/java/io/eagle/chunk/processor/CreateStockProcessor.java
+++ b/batch/src/main/java/io/eagle/chunk/processor/CreateStockProcessor.java
@@ -1,5 +1,6 @@
 package io.eagle.chunk.processor;
 
+import io.eagle.domain.ContestParticipationVO;
 import io.eagle.entity.*;
 import io.eagle.entity.type.OrderStatus;
 import io.eagle.entity.type.VacationStatusType;
@@ -22,18 +23,18 @@ public class CreateStockProcessor implements ItemProcessor<Vacation, List<Stock>
 
     @Override
     public List<Stock> process(Vacation item) throws Exception {
-        List<ContestParticipation> contestParticipations = this.findAllContestParticipationByVacation(item.getId());
+        List<ContestParticipationVO> contestParticipations = this.findAllContestParticipationByVacation(item.getId());
         Integer total = this.totalAmount(contestParticipations);
         return this.assignStocks(contestParticipations, total, item);
     }
 
-    private List<Stock> assignStocks(List<ContestParticipation> contestParticipations, Integer total, Vacation item) {
+    private List<Stock> assignStocks(List<ContestParticipationVO> contestParticipations, Integer total, Vacation item) {
         List<Stock> stocks = new ArrayList<>();
-        for (ContestParticipation contestParticipation: contestParticipations) {
-            User user = contestParticipation.getUser();
-            if (total <= 0) {
-                stocks.add(this.createStock(user, item, 0));
-            } else {
+        for (ContestParticipationVO contestParticipation: contestParticipations) {
+            System.out.println(contestParticipation.toString());
+            Long userId = contestParticipation.getUserId();
+            User user = findUserById(userId);
+            if (total > 0) {
                 Double amount = Math.ceil(contestParticipation.getStocks() * 100 / total);
                 if (total <= amount.intValue()) {
                     stocks.add(this.createStock(user, item, total));
@@ -47,8 +48,8 @@ public class CreateStockProcessor implements ItemProcessor<Vacation, List<Stock>
         return stocks;
     }
 
-    private Integer totalAmount(List<ContestParticipation> contestParticipations) {
-        return contestParticipations.stream().mapToInt(ContestParticipation::getStocks).sum();
+    private Integer totalAmount(List<ContestParticipationVO> contestParticipations) {
+        return contestParticipations.stream().mapToInt(ContestParticipationVO::getStocks).sum();
     }
 
     private Stock createStock(User user, Vacation vacation, Integer amount) {
@@ -60,11 +61,25 @@ public class CreateStockProcessor implements ItemProcessor<Vacation, List<Stock>
             .build();
     }
 
-    private List<ContestParticipation> findAllContestParticipationByVacation(Long vacationId) {
+    private List<ContestParticipationVO> findAllContestParticipationByVacation(Long vacationId) {
         return jdbcTemplate.query(
-            "select * from contest_participation as c where c.cahoots_id = ?",
-            new BeanPropertyRowMapper<>(ContestParticipation.class),
+            "select c.id, c.user_id as userId, c.cahoots_id as vacationId, c.stocks, c.status" +
+                " from contest_participation as c where c.cahoots_id = ?",
+            new BeanPropertyRowMapper<>(ContestParticipationVO.class),
             vacationId
         );
+    }
+
+    private User findUserById(Long userId) {
+        List<User> users = jdbcTemplate.query(
+            "select * from user as u where u.id = ?",
+            new BeanPropertyRowMapper<>(User.class),
+            userId
+        );
+
+        if (users == null || users.size() < 1) {
+            return null;
+        }
+        return users.get(0);
     }
 }

--- a/batch/src/main/java/io/eagle/chunk/processor/CreateStockProcessor.java
+++ b/batch/src/main/java/io/eagle/chunk/processor/CreateStockProcessor.java
@@ -31,17 +31,16 @@ public class CreateStockProcessor implements ItemProcessor<Vacation, List<Stock>
     private List<Stock> assignStocks(List<ContestParticipationVO> contestParticipations, Integer total, Vacation item) {
         List<Stock> stocks = new ArrayList<>();
         for (ContestParticipationVO contestParticipation: contestParticipations) {
-            System.out.println(contestParticipation.toString());
             Long userId = contestParticipation.getUserId();
             User user = findUserById(userId);
             if (total > 0) {
-                Double amount = Math.ceil(contestParticipation.getStocks() * 100 / total);
-                if (total <= amount.intValue()) {
+                Integer amount = Math.round(contestParticipation.getStocks() * item.getStock().getNum() / total);
+                if (total <= amount) {
                     stocks.add(this.createStock(user, item, total));
                     total = 0;
                 } else {
                     stocks.add(this.createStock(user, item, amount.intValue()));
-                    total -= amount.intValue();
+                    total -= amount;
                 }
             }
         }

--- a/batch/src/main/java/io/eagle/domain/ContestParticipationVO.java
+++ b/batch/src/main/java/io/eagle/domain/ContestParticipationVO.java
@@ -1,0 +1,17 @@
+package io.eagle.domain;
+
+import io.eagle.entity.type.ContestParticipationStatus;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ContestParticipationVO {
+
+    private Long id;
+    private Long userId;
+    private Long vacationId;
+    private Integer stocks;
+    private ContestParticipationStatus status;
+
+}


### PR DESCRIPTION
## 💬 Issue Number

> closes #193

## 🤷‍♂️ Description

> 작업 내용에 대한 설명

- [x] ContestParticipationVO 생성
- [x] Stock 생성 시 User null 에러 수정

## 📷 Screenshots

> 작업 결과물

<img width="1154" alt="스크린샷 2023-04-16 오후 2 15 17" src="https://user-images.githubusercontent.com/55318896/232272416-fd62abf2-c765-42f2-ba9c-ba460cf026cf.png">

## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?

## 또다른 이슈

현재 30 주에서 1명이 20주를 사고 나머지 한명이 10주를 샀는데 Double에서 int로 변경되는 과정에서 한 사람에게 20/30 -> 올림하면 30이 되어 한사람에게 모두 할당이 되는 케이스가 존재하는데 이때는 어떻게 해야할까요?
