### PR TITLE
공모 상세 정보 쿼리 개선

### DIFF
--- a/api/src/main/java/io/eagle/domain/vacation/dto/response/DetailCahootsDto.java
+++ b/api/src/main/java/io/eagle/domain/vacation/dto/response/DetailCahootsDto.java
@@ -1,5 +1,6 @@
 package io.eagle.domain.vacation.dto.response;
 
+import io.eagle.domain.vacation.vo.DetailCahootsVO;
 import io.eagle.entity.type.ThemeBuildingType;
 import io.eagle.entity.type.ThemeLocationType;
 import io.eagle.entity.type.VacationStatusType;
@@ -9,10 +10,14 @@ import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Data
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class DetailCahootsDto {
 
     private Long id;
@@ -49,33 +54,42 @@ public class DetailCahootsDto {
 
     private Integer expectedRateOfReturn;
 
-    // TODO : hashtag
-
     private List<String> images;
 
     private Integer interestCount;
 
     private Boolean isInterest;
 
-//    public static DetailCahootsDto toDto(Vacation vacation, Integer competitionRate) {
-//        return DetailCahootsDto.builder()
-//                .id(vacation.getId())
-//                .title(vacation.getTitle())
-//                .descritption(vacation.getDescritption())
-//                .location(vacation.getLocation())
-//                .expectedMonth(vacation.getPlan().getExpectedMonth())
-//                .expectedTotalCost(vacation.getPlan().getExpectedTotalCost())
-//                .shortDescription(vacation.getShortDescription())
-//                .stockStart(vacation.getStockPeriod().getStart())
-//                .stockEnd(vacation.getStockPeriod().getEnd())
-//                .stockPrice(vacation.getStock().getPrice())
-//                .competitionRate(competitionRate)
-//                .themeLocation(vacation.getTheme().getThemeLocation())
-//                .themeBuilding(vacation.getTheme().getThemeBuilding())
-//                .status(vacation.getStatus())
-//                .build();
-//
-//    }
+    public static DetailCahootsDto toDto(List<DetailCahootsVO> vacationDetailList) {
+        if(vacationDetailList.size() == 0){
+            throw new ApiException(ErrorCode.VACATION_NOT_FOUND);
+        }
+        DetailCahootsVO vd = vacationDetailList.get(0);
+        List<String> images = vacationDetailList.stream().map(DetailCahootsVO::getImages).collect(Collectors.toList());
+
+        return DetailCahootsDto.builder()
+                .id(vd.getId())
+                .title(vd.getTitle())
+                .country(vd.getCountry())
+                .description(vd.getDescription())
+                .location(vd.getLocation())
+                .expectedMonth(vd.getExpectedMonth())
+                .expectedTotalCost(vd.getExpectedTotalCost())
+                .shortDescription(vd.getShortDescription())
+                .stockStart(vd.getStockStart())
+                .stockEnd(vd.getStockEnd())
+                .stockPrice(vd.getStockPrice())
+                .stockNum(vd.getStockNum())
+                .competitionRate(vd.getCompetitionRate())
+                .expectedRateOfReturn(vd.getExpectedRateOfReturn())
+                .themeLocation(vd.getThemeLocation())
+                .themeBuilding(vd.getThemeBuilding())
+                .status(vd.getStatus())
+                .images(images)
+                .interestCount(vd.getInterestCount())
+                .isInterest(vd.getIsInterest())
+                .build();
+    }
 
     public DetailCahootsDto checkNull(){
         if(this.id == null) {

--- a/api/src/main/java/io/eagle/domain/vacation/repository/VacationCustom.java
+++ b/api/src/main/java/io/eagle/domain/vacation/repository/VacationCustom.java
@@ -2,6 +2,7 @@ package io.eagle.domain.vacation.repository;
 
 import io.eagle.domain.vacation.dto.*;
 import io.eagle.domain.vacation.dto.response.*;
+import io.eagle.domain.vacation.vo.DetailCahootsVO;
 import io.eagle.entity.Vacation;
 import io.eagle.entity.type.VacationStatusType;
 import org.springframework.data.domain.Pageable;
@@ -10,6 +11,7 @@ import java.util.List;
 
 public interface VacationCustom {
     DetailCahootsDto getVacationDetail(Long cahootsId);
+    List<DetailCahootsVO> findVacationDetail(Long cahootsId, Long userId);
 
     List<Long> findVacationIdByUserInterested(Long userId);
     List<BreifCahootsDto> getVacationsBreif(InfoConditionDto infoConditionDto);

--- a/api/src/main/java/io/eagle/domain/vacation/service/CahootsService.java
+++ b/api/src/main/java/io/eagle/domain/vacation/service/CahootsService.java
@@ -4,6 +4,7 @@ import io.eagle.domain.interest.repository.InterestRepository;
 import io.eagle.domain.picture.S3;
 import io.eagle.domain.vacation.dto.request.CreateCahootsDto;
 import io.eagle.domain.vacation.dto.response.*;
+import io.eagle.domain.vacation.vo.DetailCahootsVO;
 import io.eagle.entity.Interest;
 import io.eagle.entity.Picture;
 import io.eagle.domain.picture.repository.PictureRepository;
@@ -45,12 +46,8 @@ public class CahootsService {
     }
 
     public DetailCahootsDto getDetail(Long cahootsId, Long userId) {
-        DetailCahootsDto detailCahootsDto = vacationRepository.getVacationDetail(cahootsId).checkNull();
-        List<Interest> interests = interestRepository.findByVacation(vacationRepository.getReferenceById(cahootsId));
-        detailCahootsDto.setInterestCount(interests.size());
-        Boolean isInterest = (userId != null ? interests.stream().map(Interest::getUser).map(User::getId).anyMatch(id -> id.equals(userId)) : false);
-        detailCahootsDto.setIsInterest(isInterest);
-        detailCahootsDto.setImages(getImageUrls(cahootsId));
+        List<DetailCahootsVO> vacationDetailList = vacationRepository.findVacationDetail(cahootsId, userId);
+        DetailCahootsDto detailCahootsDto = DetailCahootsDto.toDto(vacationDetailList);
         return detailCahootsDto;
     }
 

--- a/api/src/main/java/io/eagle/domain/vacation/vo/DetailCahootsVO.java
+++ b/api/src/main/java/io/eagle/domain/vacation/vo/DetailCahootsVO.java
@@ -1,0 +1,54 @@
+package io.eagle.domain.vacation.vo;
+
+import io.eagle.entity.type.ThemeBuildingType;
+import io.eagle.entity.type.ThemeLocationType;
+import io.eagle.entity.type.VacationStatusType;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class DetailCahootsVO {
+    private Long id;
+    private String title;
+
+    private ThemeLocationType themeLocation;
+
+    private ThemeBuildingType themeBuilding;
+
+    private String country;
+    private String location;
+
+    private Integer expectedMonth;
+
+    private Long expectedTotalCost;
+
+    @NotBlank
+    private String shortDescription;
+
+    @NotBlank
+    private String description;
+
+    private VacationStatusType status;
+
+    private LocalDate stockStart;
+
+    private LocalDate stockEnd;
+
+    private Long stockPrice;
+
+    private Integer stockNum;
+
+    private Integer competitionRate;
+
+    private Integer expectedRateOfReturn;
+    private String images;
+
+    private Integer interestCount;
+
+    private Boolean isInterest;
+}


### PR DESCRIPTION
## 💬 Issue Number

> none

## 🤷‍♂️ Description

> 작업 내용에 대한 설명

AS-IS : 공모 상세 정보를 위해 쿼리를 3번 수행
TO-BE : vacation, interest, contest_participation, picture 을 join 하여 쿼리 한번 수행


## 📷 Screenshots

> 작업 결과물

DB SQL문 직접 요청으로 확인 시 개선으로 약 1/3의 시간 소요 확인

![image](https://user-images.githubusercontent.com/34162358/233020780-17833484-f20d-4e15-a327-611bb91ce6a5.png)

성능 평가 시 p95 약 1/3배 시간 소요 확인

![image](https://user-images.githubusercontent.com/34162358/233020968-504cb25e-3bf5-4d62-bd4f-36fcfc9a525c.png)

기존 data

![image](https://user-images.githubusercontent.com/34162358/233021402-25bcb6f0-3a4f-4372-ab91-1ff80c1ade90.png)

query 수정 data

![image](https://user-images.githubusercontent.com/34162358/233021738-11c246d7-615f-4524-956a-d7734b6130fe.png)


## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?

